### PR TITLE
[bug] destroy was not properly destroying configured secrets

### DIFF
--- a/sgt.go
+++ b/sgt.go
@@ -277,7 +277,7 @@ func main() {
 					}
 				}
 				if *secrets {
-					err := deploy.Secrets(curdir, *environ)
+					err := deploy.DestroySecrets(curdir, *environ)
 					if err != nil {
 						logger.Fatal(err)
 					}


### PR DESCRIPTION
to: @securityclippy, @mattjane-okta 

### Changes

* Fixing error where the destroy process was inadvertently calling the deploy `Secrets` function instead of the `DestroySecrets` function.