### PR TITLE
[deploy] simplifying config loading/validation

### DIFF
--- a/sgt.go
+++ b/sgt.go
@@ -165,8 +165,11 @@ func main() {
 			//err := deploy.CheckEnvironMatchConfig(*environ)
 			deploy.ErrorCheck(err)
 			//deploy.CreateDeployDirectory(*environ)
+
+			// Load the config to be passed to all deploy functions that require it
+			config := deploy.ParseDeploymentConfig(*environ)
 			if *all {
-				err := deploy.DeployAll(curdir, *environ)
+				err := deploy.DeployAll(config, curdir, *environ)
 				if err != nil {
 					logger.Error(err)
 					os.Exit(0)
@@ -215,24 +218,25 @@ func main() {
 					}
 				}
 				if *packs {
-					err := deploy.DeployDefaultPacks(*environ)
+					err := deploy.DeployDefaultPacks(config, *environ)
 					if err != nil {
 						logger.Error(err)
 					}
 				}
 				if *configs {
-					err := deploy.DeployDefaultConfigs(*environ)
+					err := deploy.DeployDefaultConfigs(config, *environ)
 					if err != nil {
 						logger.Error(err)
 					}
 				}
 				if *endpoints {
-					err := deploy.GenerateEndpointDeployScripts(*environ)
+					err := deploy.GenerateEndpointDeployScripts(config, *environ)
 					if err != nil {
 						logger.Error(err)
 					}
 				}
 			}
+			return
 		}
 		if *destroy {
 			curdir, err := os.Getwd()


### PR DESCRIPTION
to @securityclippy , @mattjane-okta 
resolves: #10 

### Changes

* Deploy process will load the `DeploymentConfig` once at start and pass it around to functions that require it as necessary
* A config file that fails to load will exit with an error status of 1
* Fixing bug in `sgt.go` where deploy process should have returned but could fall through to destroy if both flags were unintentionally used together. See [here](https://github.com/OktaSecurityLabs/sgt/compare/master...ryandeivert:ryandeivert-config-simplified?expand=1#diff-399d4f05a4886352e7a30bd6784ff074R239).
* `CheckEnvironMatchConfig` is now a function of `DeploymentConfig` struct to simplify validation and will be called when the config is loaded through `ParseDeploymentConfig`