### PR TITLE
[deploy] general consolidation and updates to error handling

### DIFF
--- a/handlers/deploy/deploy.go
+++ b/handlers/deploy/deploy.go
@@ -548,53 +548,43 @@ func DestroyVPC(top_level_dir, environ string) error {
 func DeployAll(config DeploymentConfig, top_level_dir, environ string) error {
 	err := VPC(top_level_dir, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	err = Datastore(top_level_dir, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	err = Elasticsearch(top_level_dir, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	err = Firehose(top_level_dir, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	err = S3(top_level_dir, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	err = Secrets(top_level_dir, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	err = Autoscaling(top_level_dir, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	err = DeployDefaultPacks(config, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	err = DeployDefaultConfigs(config, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	err = GenerateEndpointDeployScripts(config, environ)
 	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
+		return err
 	}
 	return nil
 }
@@ -734,8 +724,7 @@ func DeployWizard() error {
 		}
 		err = DeployAll(config, curdir, config.Environment)
 		if err != nil {
-			logger.Error(err)
-			return err
+			logger.Fatal(err)
 		}
 	}
 	return nil

--- a/handlers/deploy/deploy.go
+++ b/handlers/deploy/deploy.go
@@ -24,6 +24,8 @@ import (
 	osq_types "github.com/oktasecuritylabs/sgt/osquery_types"
 )
 
+var spin = spinner.New(spinner.CharSets[43], time.Millisecond*500)
+
 type DeploymentConfig struct {
 	Environment                 string `json:"environment"`
 	AWSProfile                  string `json:"aws_profile"`
@@ -82,14 +84,14 @@ func ParseDeploymentConfig(environ string) DeploymentConfig {
 		logger.Fatal(err)
 	}
 
-	if err = depConf.CheckEnvironMatchConfig(environ); err != nil {
+	if err = depConf.checkEnvironMatchConfig(environ); err != nil {
 		logger.Fatal(err)
 	}
 
 	return depConf
 }
 
-func (d DeploymentConfig) CheckEnvironMatchConfig(environ string) error {
+func (d DeploymentConfig) checkEnvironMatchConfig(environ string) error {
 	if d.Environment != environ {
 		return errors.New("config environment and passed environment variable do not match")
 	}
@@ -139,15 +141,13 @@ func VPC(top_level_dir, environ string) error {
 	//args := fmt.Sprintf("terraform apply -var aws_profile=%s", config.AWSProfile)
 	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
 	logger.Info(args)
-	s := spinner.New(spinner.CharSets[43], time.Millisecond*500)
-	s.Start()
+	spin.Start()
+	defer spin.Stop()
 	cmd = exec.Command("bash", "-c", args)
 	stdoutStderr, err = cmd.CombinedOutput()
 	logger.Info(string(stdoutStderr))
-	s.Stop()
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
-	s.Stop()
 	return nil
 }
 
@@ -178,7 +178,6 @@ func Datastore(top_level_dir, environ string) error {
 	logger.Info(string(stdoutStderr))
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
-	//s.Stop()
 	return nil
 }
 
@@ -273,11 +272,10 @@ func Elasticsearch(top_level_dir, environ string) error {
 	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
 	logger.Info(args)
 	cmd = exec.Command("bash", "-c", args)
-	s := spinner.New(spinner.CharSets[43], 500*time.Millisecond)
-	s.Start()
+	spin.Start()
+	defer spin.Stop()
 	stdoutStderr, err = cmd.CombinedOutput()
 	logger.Info(string(stdoutStderr))
-	s.Stop()
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
 	time.Sleep(time.Second * 10)
@@ -311,11 +309,11 @@ func Firehose(top_level_dir, environ string) error {
 	//args := fmt.Sprintf("terraform apply -var aws_profile=%s -var s3_bucket_name=%s", config.AWSProfile, config.LogBucketName)
 	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
 	logger.Info(args)
-	s := spinner.New(spinner.CharSets[43], time.Millisecond*500)
-	s.Start()
+	spin.Start()
+	defer spin.Stop()
 	cmd = exec.Command("bash", "-c", args)
 	stdoutStderr, err = cmd.CombinedOutput()
-	s.Stop()
+
 	logger.Info(string(stdoutStderr))
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
@@ -405,10 +403,10 @@ func Autoscaling(top_level_dir, environ string) error {
 	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
 	logger.Info(args)
 	cmd = exec.Command("bash", "-c", args)
-	s := spinner.New(spinner.CharSets[43], time.Millisecond*500)
-	s.Start()
+	spin.Start()
+	defer spin.Stop()
 	stdoutStderr, err = cmd.CombinedOutput()
-	s.Stop()
+
 	logger.Info(string(stdoutStderr))
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
@@ -424,10 +422,10 @@ func DestroyAutoscaling(top_level_dir, environ string) error {
 	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
 	logger.Info(args)
 	cmd := exec.Command("bash", "-c", args)
-	s := spinner.New(spinner.CharSets[43], time.Millisecond*500)
-	s.Start()
+	spin.Start()
+	defer spin.Stop()
 	stdoutStderr, err := cmd.CombinedOutput()
-	s.Stop()
+
 	logger.Info(string(stdoutStderr))
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
@@ -477,9 +475,9 @@ func DestroyFirehose(top_level_dir, environ string) error {
 	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
 	logger.Info(args)
 	cmd := exec.Command("bash", "-c", args)
-	s := spinner.New(spinner.CharSets[43], time.Millisecond*500)
+	spin.Start()
+	defer spin.Stop()
 	stdoutStderr, err := cmd.CombinedOutput()
-	s.Stop()
 	logger.Info(string(stdoutStderr))
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
@@ -497,10 +495,10 @@ func DestroyElasticsearch(top_level_dir, environ string) error {
 	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
 	logger.Info(args)
 	cmd := exec.Command("bash", "-c", args)
-	s := spinner.New(spinner.CharSets[43], 500*time.Millisecond)
-	s.Start()
+	spin.Start()
+	defer spin.Stop()
 	stdoutStderr, err := cmd.CombinedOutput()
-	s.Stop()
+
 	logger.Info(string(stdoutStderr))
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
@@ -522,7 +520,6 @@ func DestroyDatastore(top_level_dir, environ string) error {
 	logger.Info(string(stdoutStderr))
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
-	//s.Stop()
 	return nil
 }
 
@@ -535,10 +532,10 @@ func DestroyVPC(top_level_dir, environ string) error {
 	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
 	logger.Info(args)
 	cmd := exec.Command("bash", "-c", args)
-	s := spinner.New(spinner.CharSets[43], time.Millisecond*500)
-	s.Start()
+	spin.Start()
+	defer spin.Stop()
 	stdoutStderr, err := cmd.CombinedOutput()
-	s.Stop()
+
 	logger.Info(string(stdoutStderr))
 	err = os.Chdir(top_level_dir)
 	ErrorCheck(err)
@@ -780,8 +777,8 @@ func DeployDefaultPacks(config DeploymentConfig, environ string) error {
 			return err
 		}
 	}
-	s := spinner.New(spinner.CharSets[43], time.Millisecond*500)
-	s.Start()
+	spin.Start()
+	defer spin.Stop()
 	for _, fn := range files {
 		_, filename := filepath.Split(fn)
 		if strings.HasSuffix(filename, "json") {
@@ -828,7 +825,7 @@ func DeployDefaultPacks(config DeploymentConfig, environ string) error {
 			}
 		}
 	}
-	s.Stop()
+
 	return nil
 }
 
@@ -857,8 +854,8 @@ func DeployDefaultConfigs(config DeploymentConfig, environ string) error {
 			return err
 		}
 	}
-	s := spinner.New(spinner.CharSets[43], time.Millisecond*500)
-	s.Start()
+	spin.Start()
+	defer spin.Stop()
 	credfile, err := UserAwsCredFile()
 	if err != nil {
 		logger.Fatal(err)
@@ -915,7 +912,7 @@ func DeployDefaultConfigs(config DeploymentConfig, environ string) error {
 		named_config.Osquery_config = config
 		mu := sync.Mutex{}
 		ans := dyndb.UpsertNamedConfig(dync_svc, &named_config, mu)
-		s.Stop()
+
 		if ans {
 			logger.Infof("%s: success\n", named_config.Config_name)
 		} else {

--- a/handlers/deploy/deploy.go
+++ b/handlers/deploy/deploy.go
@@ -68,7 +68,7 @@ func ErrorCheck(err error) {
 
 // ParseDeploymentConfig returns the loaded config given its path
 // on disk or exits with status 1 on failure
-func ParseDeploymentConfig(environ string) *DeploymentConfig {
+func ParseDeploymentConfig(environ string) DeploymentConfig {
 	configFilePath := fmt.Sprintf("terraform/%s/%s.json", environ, environ)
 	file, err := os.Open(configFilePath)
 	if err != nil {
@@ -77,8 +77,8 @@ func ParseDeploymentConfig(environ string) *DeploymentConfig {
 
 	decoder := json.NewDecoder(file)
 
-	depConf := &DeploymentConfig{}
-	if err = decoder.Decode(depConf); err != nil {
+	depConf := DeploymentConfig{}
+	if err = decoder.Decode(&depConf); err != nil {
 		logger.Fatal(err)
 	}
 
@@ -89,7 +89,7 @@ func ParseDeploymentConfig(environ string) *DeploymentConfig {
 	return depConf
 }
 
-func (d *DeploymentConfig) CheckEnvironMatchConfig(environ string) error {
+func (d DeploymentConfig) CheckEnvironMatchConfig(environ string) error {
 	if d.Environment != environ {
 		return errors.New("config environment and passed environment variable do not match")
 	}
@@ -545,7 +545,7 @@ func DestroyVPC(top_level_dir, environ string) error {
 	return nil
 }
 
-func DeployAll(config *DeploymentConfig, top_level_dir, environ string) error {
+func DeployAll(config DeploymentConfig, top_level_dir, environ string) error {
 	err := VPC(top_level_dir, environ)
 	if err != nil {
 		logger.Error(err)
@@ -732,7 +732,7 @@ func DeployWizard() error {
 			logger.Error(err)
 			return err
 		}
-		err = DeployAll(&config, curdir, config.Environment)
+		err = DeployAll(config, curdir, config.Environment)
 		if err != nil {
 			logger.Error(err)
 			return err
@@ -770,7 +770,7 @@ type TFOutput struct {
 	Value     string `json:"value"`
 }
 
-func DeployDefaultPacks(config *DeploymentConfig, environ string) error {
+func DeployDefaultPacks(config DeploymentConfig, environ string) error {
 	var files []string
 
 	//if environ specific dir exists in packs, deploy those.  Otherwise use defaults
@@ -843,7 +843,7 @@ func DeployDefaultPacks(config *DeploymentConfig, environ string) error {
 	return nil
 }
 
-func DeployDefaultConfigs(config *DeploymentConfig, environ string) error {
+func DeployDefaultConfigs(config DeploymentConfig, environ string) error {
 	var files []string
 
 	//if environ specific dir exists in packs, deploy those.  Otherwise use defaults
@@ -964,7 +964,7 @@ func FindAndReplace(filename, original, replacement string) error {
 	return nil
 }
 
-func GenerateEndpointDeployScripts(config *DeploymentConfig, environ string) error {
+func GenerateEndpointDeployScripts(config DeploymentConfig, environ string) error {
 	logger.Infof("Updating endpoint deployments scripts for %s environment...\n", environ)
 
 	// make sure all dirs are created

--- a/handlers/deploy/deploy.go
+++ b/handlers/deploy/deploy.go
@@ -99,7 +99,7 @@ func (d *DeploymentConfig) CheckEnvironMatchConfig(environ string) error {
 func CreateDeployDirectory(environ string) error {
 	path := fmt.Sprintf("terraform/%s", environ)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		logger.Info(fmt.Sprintf("creating new deployment environment: %s", environ))
+		logger.Infof("creating new deployment environment: %s\n", environ)
 		os.Mkdir(path, 0755)
 	} else {
 		logger.Info("environment already exists, are you sure you meant to to use deploy to\n")
@@ -111,7 +111,7 @@ func CreateDeployDirectory(environ string) error {
 		dir := filepath.Join(path, p)
 		//logger.Info(dir)
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			logger.Info(fmt.Sprintf("Creating %s directory", dir))
+			logger.Infof("Creating %s directory\n", dir)
 			os.Mkdir(dir, 0755)
 		}
 	}
@@ -775,7 +775,7 @@ func DeployDefaultPacks(config *DeploymentConfig, environ string) error {
 
 	//if environ specific dir exists in packs, deploy those.  Otherwise use defaults
 	if _, err := os.Stat(filepath.Join("packs", environ)); os.IsNotExist(err) {
-		logger.Info(fmt.Sprintf("No environment specific packs found for: %s", environ))
+		logger.Infof("No environment specific packs found for: %s\n", environ)
 		logger.Info("using default packs")
 		files, err = filepath.Glob("packs/*")
 		if err != nil {
@@ -783,7 +783,7 @@ func DeployDefaultPacks(config *DeploymentConfig, environ string) error {
 			return err
 		}
 	} else {
-		logger.Info(fmt.Sprintf("Environment specific folder found for: %s \nUsing %s query packs", environ, environ))
+		logger.Infof("Environment specific folder found for: %s\nUsing %s query packs\n", environ, environ)
 		path := fmt.Sprintf("packs/%s/*", environ)
 		files, err = filepath.Glob(path)
 		if err != nil {
@@ -849,7 +849,7 @@ func DeployDefaultConfigs(config *DeploymentConfig, environ string) error {
 	//if environ specific dir exists in packs, deploy those.  Otherwise use defaults
 	env_specific_configs := false
 	if _, err := os.Stat(filepath.Join("osquery_configs", environ)); os.IsNotExist(err) {
-		logger.Info(fmt.Sprintf("No environment specific configs found for: %s", environ))
+		logger.Infof("No environment specific configs found for: %s\n", environ)
 		logger.Info("using default configs")
 		files, err = filepath.Glob("osquery_configs/defaults/*")
 		environ = "defaults"
@@ -859,7 +859,7 @@ func DeployDefaultConfigs(config *DeploymentConfig, environ string) error {
 			return err
 		}
 	} else {
-		logger.Info(fmt.Sprintf("Environment specific folder found for: %s \nUsing %s configs", environ, environ))
+		logger.Infof("Environment specific folder found for: %s\nUsing %s configs\n", environ, environ)
 		path := fmt.Sprintf("osquery_configs/%s/*", environ)
 		env_specific_configs = true
 		files, err = filepath.Glob(path)
@@ -928,9 +928,9 @@ func DeployDefaultConfigs(config *DeploymentConfig, environ string) error {
 		ans := dyndb.UpsertNamedConfig(dync_svc, &named_config, mu)
 		s.Stop()
 		if ans {
-			logger.Info(fmt.Sprintf("%s: success", named_config.Config_name))
+			logger.Infof("%s: success\n", named_config.Config_name)
 		} else {
-			logger.Info(fmt.Sprintf("%s: failed", named_config.Config_name))
+			logger.Infof("%s: failed\n", named_config.Config_name)
 		}
 	}
 	return nil
@@ -965,7 +965,7 @@ func FindAndReplace(filename, original, replacement string) error {
 }
 
 func GenerateEndpointDeployScripts(config *DeploymentConfig, environ string) error {
-	logger.Info(fmt.Sprintf("Updating endpoint deployments scripts for %s environment...", environ))
+	logger.Infof("Updating endpoint deployments scripts for %s environment...\n", environ)
 
 	// make sure all dirs are created
 	err := CreateDirIfNotExists(filepath.Join("endpoints", "deploy", environ))

--- a/handlers/deploy/deploy.go
+++ b/handlers/deploy/deploy.go
@@ -60,13 +60,10 @@ func CopyFile(src, dst string) error {
 	return out.Close()
 }
 
-func ErrorCheck(err error) error {
+func ErrorCheck(err error) {
 	if err != nil {
-		logger.Error(err)
 		logger.Fatal(err)
-		return err
 	}
-	return nil
 }
 
 // ParseDeploymentConfig returns the loaded config given its path
@@ -138,9 +135,7 @@ func VPC(top_level_dir, environ string) error {
 	ErrorCheck(err)
 	cmd := exec.Command("terraform", "init")
 	stdoutStderr, err := cmd.CombinedOutput()
-	if err = ErrorCheck(err); err != nil {
-		return err
-	}
+	ErrorCheck(err)
 	//args := fmt.Sprintf("terraform apply -var aws_profile=%s", config.AWSProfile)
 	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
 	logger.Info(args)
@@ -273,9 +268,7 @@ func Elasticsearch(top_level_dir, environ string) error {
 	ErrorCheck(err)
 	cmd := exec.Command("terraform", "init")
 	stdoutStderr, err := cmd.CombinedOutput()
-	if err = ErrorCheck(err); err != nil {
-		return err
-	}
+	ErrorCheck(err)
 	//args := fmt.Sprintf("terraform apply -var aws_profile=%s -var user_ip_address=%s", config.AWSProfile, config.UserIPAddress)
 	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
 	logger.Info(args)
@@ -314,9 +307,7 @@ func Firehose(top_level_dir, environ string) error {
 	ErrorCheck(err)
 	cmd := exec.Command("terraform", "init")
 	stdoutStderr, err := cmd.CombinedOutput()
-	if err = ErrorCheck(err); err != nil {
-		return err
-	}
+	ErrorCheck(err)
 	//args := fmt.Sprintf("terraform apply -var aws_profile=%s -var s3_bucket_name=%s", config.AWSProfile, config.LogBucketName)
 	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
 	logger.Info(args)
@@ -409,9 +400,7 @@ func Autoscaling(top_level_dir, environ string) error {
 	ErrorCheck(err)
 	cmd := exec.Command("terraform", "init")
 	stdoutStderr, err := cmd.CombinedOutput()
-	if err = ErrorCheck(err); err != nil {
-		return err
-	}
+	ErrorCheck(err)
 	//args := fmt.Sprintf("terraform apply -var aws_profile=%s -var domain=%s -var subdomain=%s -var keypair=%s", config.AWSProfile, config.DomainName, config.Subdomain, config.AwsKeypair)
 	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
 	logger.Info(args)
@@ -431,9 +420,6 @@ func DestroyAutoscaling(top_level_dir, environ string) error {
 
 	err := os.Chdir(fmt.Sprintf("terraform/%s/autoscaling", environ))
 	ErrorCheck(err)
-	if err = ErrorCheck(err); err != nil {
-		return err
-	}
 	//args := fmt.Sprintf("terraform destroy -force -var aws_profile=%s -var domain=%s -var subdomain=%s -var keypair=%s", config.AWSProfile, config.DomainName, config.Subdomain, config.AwsKeypair)
 	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
 	logger.Info(args)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -22,6 +22,10 @@ func Info(args ...interface{}) {
 	logger.Info(args...)
 }
 
+func Infof(format string, args ...interface{}) {
+	logger.Infof(format, args...)
+}
+
 func Debug(args ...interface{}) {
 	logger.Debug(args...)
 }

--- a/sgt.go
+++ b/sgt.go
@@ -171,8 +171,7 @@ func main() {
 			if *all {
 				err := deploy.DeployAll(config, curdir, *environ)
 				if err != nil {
-					logger.Error(err)
-					os.Exit(0)
+					logger.Fatal(err)
 				}
 			} else {
 				if *vpc {


### PR DESCRIPTION
to @securityclippy 
resolves: #6 

### Changes

* Updating `deploy.ErrorCheck` so that the function now does not return anything and updating all calls to it. The function previously was set to return the err, despite the code being unreachable. See #6 for more context.
* Adding an `Infof` helper function to the `logger` package to simplify info logger statements that require formatting. This was previously accomplished through the combination of `logger.Info` and `fmt.Sprintf` but this avoids that complexity.
* Switching usage of `DeploymentConfig` to be passed by value instead of pointer since it's a small struct that does not ever have its contents change. This is mostly for the sake simplicity when dealing with implementing funcs on this struct.
* The return value of `DeployAll` func will now be what determines if the program should exit with an error instead of duplicating code many times within the function.
* Moving the `spinner` object to a var in the `deploy` package that can be `Start`ed and `Stop`ed throughout the various functions instead of re-creating the object each time within each deploy step. The spinner var will now also have a `defer`ed call to `Stop` after it is started as to not have to account for stopping it after the function returns.

### Testing

* Ran `go build` to ensure everything is still compiling 👌 
