### PR TITLE
[cli/deploy] cli subcommands and deploy package revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ create the proper directory structure and the environment specific configuration
 files and stand up the environment if you choose to do so
 
 ```commandline
-./sgt -wizard
+./sgt wizard
 ```
 
 When you are done with the wizard, you will be prompted to either continue to deploy
@@ -91,13 +91,13 @@ still requires their dependencies to be built, they may just be updated individu
 To deploy SGT...
 
 ```commandline
-./sgt -deploy -env <environment> -all
+./sgt deploy -env <environment> -all
 ```
 
 To deploy/update an individual component..
 
 ```commandline
-./sgt -deploy -env <environment> -elasticsearch
+./sgt deploy -env <environment> -components elasticsearch,firehose
 ```
 
 for a full list of commands, issue the -h flag
@@ -111,7 +111,7 @@ to make sure this occurs before moving on to next steps
 To create a user to interact with SGT, pass the `-create_user` flag with the requisite options
 
 ```commandline
-./sgt -create_user -credentials_file <cred_file> -profile <profile> -username <username> -role <"Admin"|"User"|"Read-only">
+./sgt create-user -credentials-file <cred_file> -profile <profile> -username <username> -role <"Admin"|"User"|"Read-only">
 ```
 
 ### Getting an Authentication Token
@@ -134,4 +134,3 @@ Provide this token in any subsequent requests in the Authorization header
 ## Documentation notes:
 Documentation is lacking right now due to a rather un-fun flu season.  However, updates to documentation should be expected in teh coming week or so.
 (This note marked: 1/17/18)
-

--- a/handlers/deploy/apply.go
+++ b/handlers/deploy/apply.go
@@ -1,0 +1,214 @@
+package deploy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/oktasecuritylabs/sgt/logger"
+)
+
+// tfState struct for terraform state
+type tfState struct {
+	Version          int        `json:"version"`
+	TerraformVersion string     `json:"terraform_version"`
+	Serial           int        `json:"serial"`
+	Lineage          string     `json:"lineage"`
+	Modules          []tfModule `json:"modules"`
+}
+
+// tfModule struct for terrform modules in tfstates
+type tfModule struct {
+	Path    []string            `json:"path"`
+	Outputs map[string]tfOutput `json:"outputs"`
+}
+
+// tfOutput struct for terraform outputs from tfstate files
+type tfOutput struct {
+	Sensitive bool   `json:"sensitive"`
+	Type      string `json:"type"`
+	Value     string `json:"value"`
+}
+
+// copyComponentTemplates copies the examples to the new deploy env
+func copyComponentTemplates(component, envName string) (string, error) {
+
+	files, err := filepath.Glob(fmt.Sprintf("terraform/example/%s/*", component))
+	if err != nil {
+		return "", err
+	}
+
+	componentPath := fmt.Sprintf("terraform/%s/%s", envName, component)
+
+	for _, fn := range files {
+		_, filename := filepath.Split(fn)
+		err = copyFile(fn, fmt.Sprintf("%s/%s", componentPath, filename))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return componentPath, nil
+}
+
+// AllComponents deploys all components
+func AllComponents(config DeploymentConfig, environ string) error {
+	for _, name := range DeployOrder {
+		if err := deployAWSComponent(name, environ); err != nil {
+			return err
+		}
+	}
+
+	for _, fn := range osqueryDeployCommands {
+		if err := fn(config, environ); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Component deploys both aws components and osquery components
+func Component(config DeploymentConfig, component, envName string) error {
+	if fn, ok := osqueryDeployCommands[component]; ok {
+		return fn(config, envName)
+	}
+
+	return deployAWSComponent(component, envName)
+}
+
+// deployAWSComponent handles applying the aws components with terraform
+// This includes: VPC, Datastore, Firehose, Autoscaling, Secrets
+// S3 requires building the binary
+// Elasticsearch requires creating the elasticsearch mappings
+func deployAWSComponent(component, envName string) error {
+
+	// Change back to the top level directory after each component deploy
+	cachedCurDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	defer os.Chdir(cachedCurDir)
+
+	if component == "s3" {
+		logger.Info("Making sure binary is built...")
+		cmd := exec.Command("bash", "-c", "go build sgt.go")
+		combinedOutput, buildErr := cmd.CombinedOutput()
+		if buildErr != nil {
+			return buildErr
+		}
+		logger.Info(string(combinedOutput))
+	}
+
+	logger.Infof("Building %s...\n", component)
+
+	spin.Start()
+	defer spin.Stop()
+
+	componentPath, err := copyComponentTemplates(component, envName)
+	if err != nil {
+		return err
+	}
+
+	if err = os.Chdir(componentPath); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("terraform", "init")
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	args := fmt.Sprintf("terraform apply -var-file=../%s.json", envName)
+	logger.Info(args)
+
+	cmd = exec.Command("bash", "-c", args)
+	stdoutStderr, err = cmd.CombinedOutput()
+
+	logger.Info(string(stdoutStderr))
+
+	if component == "elasticsearch" {
+		time.Sleep(time.Second * 10)
+
+		// ElasticSearchMappings("https://search-sgt-osquery-results-r6owrsyarql42ttzy26fz6nf24.us-east-1.es.amazonaws.com")
+		return createElasticSearchMappings()
+	}
+
+	return err
+}
+
+// createElasticSearchMappings creates Elasticsearch mappings
+func createElasticSearchMappings() error {
+
+	fn := "terraform.tfstate"
+	file, err := os.Open(fn)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	decoder := json.NewDecoder(file)
+	tfstate := tfState{}
+	if err = decoder.Decode(&tfstate); err != nil {
+		return err
+	}
+
+	var esEndpoint string
+	for _, i := range tfstate.Modules {
+		for k, v := range i.Outputs {
+			if k == "elasticearch_endpoint" {
+				if !strings.Contains(v.Value, "amazon.com") {
+					esEndpoint = v.Value
+					break
+				}
+			}
+		}
+	}
+
+	logger.Info(esEndpoint)
+	//esEndpoint := "https://search-sgt-osquery-results-r6owrsyarql42ttzy26fz6nf24.us-east-1.es.amazonaws.com"
+	path := "_template/template_1"
+	rawJSON := json.RawMessage(`{
+  "template": "osquery_*",
+  "settings": {
+    "number_of_shards": 4
+  },
+  "mappings": {
+    "_default_": {
+      "properties": {
+        "calendarTime": {
+          "type": "date",
+          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
+        },
+        "unixTime": {
+          "type": "date"
+        }
+      }
+    }
+  }
+}`)
+
+	uri := fmt.Sprintf("https://%s/%s", esEndpoint, path)
+	logger.Info(uri)
+
+	req, _ := http.NewRequest("PUT", uri, bytes.NewBuffer(rawJSON))
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	response, _ := client.Do(req)
+	fmt.Println(response.Status)
+	body, _ := ioutil.ReadAll(response.Body)
+	fmt.Println(string(body))
+	if response.Status != "200 OK" {
+		return errors.New(string(body))
+	}
+
+	return nil
+}

--- a/handlers/deploy/deploy.go
+++ b/handlers/deploy/deploy.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
@@ -24,9 +22,48 @@ import (
 	osq_types "github.com/oktasecuritylabs/sgt/osquery_types"
 )
 
-var spin = spinner.New(spinner.CharSets[43], time.Millisecond*500)
+const (
+	vpc           = "vpc"
+	datastore     = "datastore"
+	elasticsearch = "elasticsearch"
+	firehose      = "firehose"
+	s3            = "s3"
+	secrets       = "secrets"
+	autoscaling   = "autoscaling"
+	packs         = "packs"
+	configs       = "configs"
+	scripts       = "scripts"
+)
 
-//DeploymentConfig configuration file used by all environment deployments
+var (
+	spin = spinner.New(spinner.CharSets[43], time.Millisecond*500)
+
+	// DeployOrder dictates what order the deployed components should happen in
+	DeployOrder = []string{
+		vpc,
+		datastore,
+		elasticsearch,
+		firehose,
+		s3,
+		secrets,
+		autoscaling,
+	}
+
+	// OsqueryOpts holds all deploy options for osquery
+	OsqueryOpts = []string{
+		packs,
+		configs,
+		scripts,
+	}
+
+	osqueryDeployCommands = map[string]func(DeploymentConfig, string) error{
+		packs:   osqueryDefaultPacks,
+		configs: osqueryDefaultConfigs,
+		scripts: generateEndpointDeployScripts,
+	}
+)
+
+// DeploymentConfig configuration file used by all environment deployments
 type DeploymentConfig struct {
 	Environment                 string `json:"environment"`
 	AWSProfile                  string `json:"aws_profile"`
@@ -42,8 +79,8 @@ type DeploymentConfig struct {
 	SgtAppSecret                string `json:"sgt_app_secret"`
 }
 
-//CopyFile copies file from src to dst
-func CopyFile(src, dst string) error {
+// copyFile copies file from src to dst
+func copyFile(src, dst string) error {
 	// ripped from https://stackoverflow.com/questions/21060945/simple-way-to-copy-a-file-in-golang
 	in, err := os.Open(src)
 	if err != nil {
@@ -64,34 +101,27 @@ func CopyFile(src, dst string) error {
 	return out.Close()
 }
 
-//ErrorCheck checks for an given (error) and returns a fatal error is err is not nil
-func ErrorCheck(err error) {
-	if err != nil {
-		logger.Fatal(err)
-	}
-}
-
 // ParseDeploymentConfig returns the loaded config given its path
 // on disk or exits with status 1 on failure
-func ParseDeploymentConfig(environ string) DeploymentConfig {
-	configFilePath := fmt.Sprintf("terraform/%s/%s.json", environ, environ)
+func ParseDeploymentConfig(environ string) (DeploymentConfig, error) {
+	depConf := DeploymentConfig{}
+	configFilePath := fmt.Sprintf("terraform/%[1]s/%[1]s.json", environ)
 	file, err := os.Open(configFilePath)
 	if err != nil {
-		logger.Fatal(err)
+		return depConf, err
 	}
 
 	decoder := json.NewDecoder(file)
 
-	depConf := DeploymentConfig{}
 	if err = decoder.Decode(&depConf); err != nil {
-		logger.Fatal(err)
+		return depConf, err
 	}
 
 	if err = depConf.checkEnvironMatchConfig(environ); err != nil {
-		logger.Fatal(err)
+		return depConf, err
 	}
 
-	return depConf
+	return depConf, nil
 }
 
 //checkEnvironMatchconfig checks to make sure the environment config passed matches the environment
@@ -126,631 +156,7 @@ func CreateDeployDirectory(environ string) error {
 	return nil
 }
 
-//VPC creates VPC component
-func VPC(topLevelDir, environ string) error {
-	logger.Info("Building VPC....")
-
-	files, err := filepath.Glob("terraform/example/vpc/*")
-	for _, fn := range files {
-		_, filename := filepath.Split(fn)
-		//err = CopyFile(fn, fmt.Sprintf("terraform/%s/vpc/%", environ, filename))
-		err = CopyFile(fn, fmt.Sprintf("terraform/%s/vpc/%s", environ, filename))
-		if err != nil {
-			logger.Error(err)
-		}
-	}
-
-	err = os.Chdir(fmt.Sprintf("terraform/%s/vpc", environ))
-	ErrorCheck(err)
-	cmd := exec.Command("terraform", "init")
-	stdoutStderr, err := cmd.CombinedOutput()
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform apply -var aws_profile=%s", config.AWSProfile)
-	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
-	logger.Info(args)
-	spin.Start()
-	defer spin.Stop()
-	cmd = exec.Command("bash", "-c", args)
-	stdoutStderr, err = cmd.CombinedOutput()
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//Datastore creates datastore components
-func Datastore(topLevelDir, environ string) error {
-	logger.Info("building Datastore...")
-	//s := spinner.New(spinner.CharSets[0], 500*time.Millisecond)
-	//s.Start()
-
-	files, err := filepath.Glob("terraform/example/datastore/*")
-	for _, fn := range files {
-		_, filename := filepath.Split(fn)
-		//err = CopyFile(fn, fmt.Sprintf("terraform/%s/vpc/%", environ, filename))
-		err = CopyFile(fn, fmt.Sprintf("terraform/%s/datastore/%s", environ, filename))
-		if err != nil {
-			logger.Error(err)
-		}
-	}
-
-	err = os.Chdir(fmt.Sprintf("terraform/%s/datastore", environ))
-	ErrorCheck(err)
-	cmd := exec.Command("terraform", "init")
-	stdoutStderr, err := cmd.CombinedOutput()
-	//args := fmt.Sprintf("terraform apply -var aws_profile=%s", config.AWSProfile)
-	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd = exec.Command("bash", "-c", args)
-	stdoutStderr, err = cmd.CombinedOutput()
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//ElasticSearchMappings Creates Elasticsearch mappings
-func ElasticSearchMappings(topLevelDir, environ string) error {
-	err := os.Chdir(fmt.Sprintf("terraform/%s/elasticsearch", environ))
-	ErrorCheck(err)
-	fn := "terraform.tfstate"
-	file, err := os.Open(fn)
-	if err != nil {
-		fmt.Println(err)
-	}
-	decoder := json.NewDecoder(file)
-	tfstate := TState{}
-	err = decoder.Decode(&tfstate)
-	if err != nil {
-		logger.Error(err)
-	}
-	//fmt.Printf("%+v", tfstate)
-	//fmt.Printf("%+v", tfstate.Modules[0].Outputs.(map))
-	//esEndpoint := tfstate.Modules[0].Outputs["elasticsearch_endpoint"]
-	esEndpoint := ""
-	for _, i := range tfstate.Modules {
-		//fmt.Printf("%+v", i)
-		for k, v := range i.Outputs {
-			if k == "elasticearch_endpoint" {
-				if !strings.Contains(v.Value, "amazon.com") {
-					//fmt.Println(v.Value)
-					esEndpoint = v.Value
-				}
-			}
-		}
-	}
-	logger.Info(esEndpoint)
-	//esEndpoint := "https://search-sgt-osquery-results-r6owrsyarql42ttzy26fz6nf24.us-east-1.es.amazonaws.com"
-	path := "_template/template_1"
-	rawJSON := json.RawMessage(`{
-	  "template": "osquery_*",
-	  "settings": {
-		"number_of_shards": 4},
-		"mappings": {
-		"_default_": {
-		  "properties": {
-			"calendarTime": {
-			  "type": "date",
-			  "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"
-			},
-			"unixTime": {
-			  "type": "date"
-			}
-		  }
-		}
-	  }
-	}`)
-
-	uri := fmt.Sprintf("https://%s/%s", esEndpoint, path)
-	logger.Info(uri)
-	//js, err := json.Marshal(rawJSON)
-	req, _ := http.NewRequest("PUT", uri, bytes.NewBuffer(rawJSON))
-	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{}
-	response, _ := client.Do(req)
-	fmt.Println(response.Status)
-	body, _ := ioutil.ReadAll(response.Body)
-	fmt.Println(string(body))
-	if response.Status != "200 OK" {
-		return errors.New(string(body))
-	}
-	err = os.Chdir(topLevelDir)
-	return nil
-}
-
-//Elasticsearch creates elasticsearch components
-func Elasticsearch(topLevelDir, environ string) error {
-	logger.Info("building Elasticsearch...")
-	logger.Info("Note:  Due to the way Amazon's elasticsearch service is built, this may take up to 30 minutes or more to complete")
-
-	files, err := filepath.Glob("terraform/example/elasticsearch/*")
-	for _, fn := range files {
-		_, filename := filepath.Split(fn)
-		//err = CopyFile(fn, fmt.Sprintf("terraform/%s/vpc/%", environ, filename))
-		err = CopyFile(fn, fmt.Sprintf("terraform/%s/elasticsearch/%s", environ, filename))
-		if err != nil {
-			logger.Error(err)
-		}
-	}
-
-	err = os.Chdir(fmt.Sprintf("terraform/%s/elasticsearch", environ))
-	ErrorCheck(err)
-	cmd := exec.Command("terraform", "init")
-	stdoutStderr, err := cmd.CombinedOutput()
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform apply -var aws_profile=%s -var user_ip_address=%s", config.AWSProfile, config.UserIPAddress)
-	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd = exec.Command("bash", "-c", args)
-	spin.Start()
-	defer spin.Stop()
-	stdoutStderr, err = cmd.CombinedOutput()
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	time.Sleep(time.Second * 10)
-	err = ElasticSearchMappings(topLevelDir, environ)
-	if err != nil {
-		logger.Error(err)
-		return err
-	}
-	//ElasticSearchMappings("https://search-sgt-osquery-results-r6owrsyarql42ttzy26fz6nf24.us-east-1.es.amazonaws.com")
-	return nil
-}
-
-//Firehose creates firehose components
-func Firehose(topLevelDir, environ string) error {
-	logger.Info("building Firehose(n)...")
-
-	files, err := filepath.Glob("terraform/example/firehose/*")
-	for _, fn := range files {
-		_, filename := filepath.Split(fn)
-		//err = CopyFile(fn, fmt.Sprintf("terraform/%s/vpc/%", environ, filename))
-		err = CopyFile(fn, fmt.Sprintf("terraform/%s/firehose/%s", environ, filename))
-		if err != nil {
-			logger.Error(err)
-		}
-	}
-
-	err = os.Chdir(fmt.Sprintf("terraform/%s/firehose", environ))
-	ErrorCheck(err)
-	cmd := exec.Command("terraform", "init")
-	stdoutStderr, err := cmd.CombinedOutput()
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform apply -var aws_profile=%s -var s3_bucket_name=%s", config.AWSProfile, config.LogBucketName)
-	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
-	logger.Info(args)
-	spin.Start()
-	defer spin.Stop()
-	cmd = exec.Command("bash", "-c", args)
-	stdoutStderr, err = cmd.CombinedOutput()
-
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//S3 creates s3 components
-func S3(topLevelDir, environ string) error {
-	logger.Info("Making sure binary is built...")
-	cmd := exec.Command("bash", "-c", "go build sgt.go")
-	combinedoutput, err := cmd.CombinedOutput()
-	ErrorCheck(err)
-	logger.Info(combinedoutput)
-	logger.Info("building S3...")
-
-	files, err := filepath.Glob("terraform/example/s3/*")
-	for _, fn := range files {
-		_, filename := filepath.Split(fn)
-		err = CopyFile(fn, fmt.Sprintf("terraform/%s/s3/%s", environ, filename))
-		if err != nil {
-			logger.Error(err)
-		}
-	}
-
-	err = os.Chdir(fmt.Sprintf("terraform/%s/s3", environ))
-	ErrorCheck(err)
-	cmd = exec.Command("bash", "-c", "terraform init")
-	stdoutStderr, err := cmd.CombinedOutput()
-	//args := fmt.Sprintf("terraform apply -var aws_profile=%s -var sgt_config_bucket=%s -var full_cert_chain=%s -var priv_key=%s",
-	//config.AWSProfile, config.ConfigBucketName, config.SslFullKeychain, config.SslPrivateKey)
-	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd = exec.Command("bash", "-c", args)
-	stdoutStderr, err = cmd.CombinedOutput()
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//Secrets creates secrets components
-func Secrets(topLevelDir, environ string) error {
-	logger.Info("Uploading secrets...")
-
-	files, err := filepath.Glob("terraform/example/secrets/*")
-	for _, fn := range files {
-		_, filename := filepath.Split(fn)
-		err = CopyFile(fn, fmt.Sprintf("terraform/%s/secrets/%s", environ, filename))
-		if err != nil {
-			logger.Error(err)
-		}
-	}
-
-	err = os.Chdir(fmt.Sprintf("terraform/%s/secrets", environ))
-	ErrorCheck(err)
-	cmd := exec.Command("bash", "-c", "terraform init")
-	stdoutStderr, err := cmd.CombinedOutput()
-	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
-	fmt.Println(args)
-	//config.AWSProfile, config.NodeSecret, config.AppSecret)
-	logger.Info("Args hidden due to sensitive nature...")
-	cmd = exec.Command("bash", "-c", args)
-	stdoutStderr, err = cmd.CombinedOutput()
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//Autoscaling creates autoscaling components
-func Autoscaling(topLevelDir, environ string) error {
-	logger.Info("building Autoscaling...")
-
-	files, err := filepath.Glob("terraform/example/autoscaling/*")
-	for _, fn := range files {
-		_, filename := filepath.Split(fn)
-		//err = CopyFile(fn, fmt.Sprintf("terraform/%s/vpc/%", environ, filename))
-		err = CopyFile(fn, fmt.Sprintf("terraform/%s/autoscaling/%s", environ, filename))
-		if err != nil {
-			logger.Error(err)
-		}
-	}
-
-	err = os.Chdir(fmt.Sprintf("terraform/%s/autoscaling", environ))
-	ErrorCheck(err)
-	cmd := exec.Command("terraform", "init")
-	stdoutStderr, err := cmd.CombinedOutput()
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform apply -var aws_profile=%s -var domain=%s -var subdomain=%s -var keypair=%s", config.AWSProfile, config.DomainName, config.Subdomain, config.AwsKeypair)
-	args := fmt.Sprintf("terraform apply -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd = exec.Command("bash", "-c", args)
-	spin.Start()
-	defer spin.Stop()
-	stdoutStderr, err = cmd.CombinedOutput()
-
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//DestroyAutoscaling destroys autoscaling components
-func DestroyAutoscaling(topLevelDir, environ string) error {
-	logger.Info("Destroying Autoscaling...")
-
-	err := os.Chdir(fmt.Sprintf("terraform/%s/autoscaling", environ))
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform destroy -force -var aws_profile=%s -var domain=%s -var subdomain=%s -var keypair=%s", config.AWSProfile, config.DomainName, config.Subdomain, config.AwsKeypair)
-	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd := exec.Command("bash", "-c", args)
-	spin.Start()
-	defer spin.Stop()
-	stdoutStderr, err := cmd.CombinedOutput()
-
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//DestroySecrets destroys secrets components
-func DestroySecrets(topLevelDir, environ string) error {
-	logger.Info("Destroying secrets...")
-
-	err := os.Chdir(fmt.Sprintf("terraform/%s/secrets", environ))
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform destroy -var aws_profile=%s -var sgt_node_secret=%s -var sgt_app_secret=%s",
-	//config.AWSProfile, config.NodeSecret, config.AppSecret)
-	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
-	logger.Info("Args hidden due to sensitive nature...")
-	cmd := exec.Command("bash", "-c", args)
-	stdoutStderr, err := cmd.CombinedOutput()
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//DestroyS3 destroys s3 components
-func DestroyS3(topLevelDir, environ string) error {
-	logger.Info("Destroy S3...")
-
-	err := os.Chdir(fmt.Sprintf("terraform/%s/s3", environ))
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform destroy -force -var aws_profile=%s -var sgt_config_bucket=%s -var full_cert_chain=%s -var priv_key=%s",
-	//config.AWSProfile, config.ConfigBucketName, config.SslFullKeychain, config.SslPrivateKey)
-	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd := exec.Command("bash", "-c", args)
-	stdoutStderr, err := cmd.CombinedOutput()
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//DestroyFirehose destroys firehose components
-func DestroyFirehose(topLevelDir, environ string) error {
-	logger.Info("Destrying Firehose(n)...")
-
-	err := os.Chdir(fmt.Sprintf("terraform/%s/firehose", environ))
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform destroy -force -var aws_profile=%s -var s3_bucket_name=%s", config.AWSProfile, config.LogBucketName)
-	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd := exec.Command("bash", "-c", args)
-	spin.Start()
-	defer spin.Stop()
-	stdoutStderr, err := cmd.CombinedOutput()
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//DestroyElasticsearch destroys elasticsearch components
-func DestroyElasticsearch(topLevelDir, environ string) error {
-	logger.Info("Destroying Elasticsearch...")
-	logger.Info("Note:  Due to the way Amazon's elasticsearch service is built, this may take up to 30 minutes or more to complete")
-	logger.Info("PS.  Now is probably a good time for some coffee...mmm, coffee")
-
-	err := os.Chdir(fmt.Sprintf("terraform/%s/elasticsearch", environ))
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform destroy -force -var aws_profile=%s -var user_ip_address=%s", config.AWSProfile, config.UserIPAddress)
-	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd := exec.Command("bash", "-c", args)
-	spin.Start()
-	defer spin.Stop()
-	stdoutStderr, err := cmd.CombinedOutput()
-
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//DestroyDatastore destroys datastore components
-func DestroyDatastore(topLevelDir, environ string) error {
-	logger.Info("Destroying Datastore...")
-	//s := spinner.New(spinner.CharSets[0], 500*time.Millisecond)
-	//s.Start()
-
-	err := os.Chdir(fmt.Sprintf("terraform/%s/datastore", environ))
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform destroy -force -var aws_profile=%s", config.AWSProfile)
-	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd := exec.Command("bash", "-c", args)
-	stdoutStderr, err := cmd.CombinedOutput()
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//DestroyVPC destroys vpc components
-func DestroyVPC(topLevelDir, environ string) error {
-	logger.Info("Destroying VPC....")
-
-	err := os.Chdir(fmt.Sprintf("terraform/%s/vpc", environ))
-	ErrorCheck(err)
-	//args := fmt.Sprintf("terraform destroy -force -var aws_profile=%s", config.AWSProfile)
-	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", environ)
-	logger.Info(args)
-	cmd := exec.Command("bash", "-c", args)
-	spin.Start()
-	defer spin.Stop()
-	stdoutStderr, err := cmd.CombinedOutput()
-
-	logger.Info(string(stdoutStderr))
-	err = os.Chdir(topLevelDir)
-	ErrorCheck(err)
-	return nil
-}
-
-//DeployAll deploys all components
-func DeployAll(config DeploymentConfig, topLevelDir, environ string) error {
-	err := VPC(topLevelDir, environ)
-	if err != nil {
-		return err
-	}
-	err = Datastore(topLevelDir, environ)
-	if err != nil {
-		return err
-	}
-	err = Elasticsearch(topLevelDir, environ)
-	if err != nil {
-		return err
-	}
-	err = Firehose(topLevelDir, environ)
-	if err != nil {
-		return err
-	}
-	err = S3(topLevelDir, environ)
-	if err != nil {
-		return err
-	}
-	err = Secrets(topLevelDir, environ)
-	if err != nil {
-		return err
-	}
-	err = Autoscaling(topLevelDir, environ)
-	if err != nil {
-		return err
-	}
-	err = DeployDefaultPacks(config, environ)
-	if err != nil {
-		return err
-	}
-	err = DeployDefaultConfigs(config, environ)
-	if err != nil {
-		return err
-	}
-	err = GenerateEndpointDeployScripts(config, environ)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-//DeployWizard walks through setting up an environment config and deploys
-func DeployWizard() error {
-	config := DeploymentConfig{}
-	fmt.Print("Enter new environment name.  This is typically something like" +
-		"'Dev' or 'Prod' or 'Testing, but can be anything you want it to be: ")
-	//envName, err := reader.ReadString('\n')
-	var envName string
-	_, err := fmt.Scan(&envName)
-	if err != nil {
-		return err
-	}
-	err = CreateDeployDirectory(envName)
-	if err != nil {
-		return err
-	}
-	config.Environment = envName
-	fmt.Println("Enter the name for the aws profile you'd like to use to deploy this environment \n" +
-		"if you've never created a profile before, you can read more about how to do this here\n" +
-		"http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html \n" +
-		"a 'default' profile is created if you've installed and configured the aws cli: ")
-	var profile string
-	_, err = fmt.Scan(&profile)
-	if err != nil {
-		return err
-	}
-	config.AWSProfile = profile
-	fmt.Println("Enter an ipaddress or cidr block for access to your elasticsearch cluster. \n" +
-		"Note:  This should probably be your current IP address, as you will need to be able to access \n" +
-		"elasticsearch via API to create the proper indices and mappings when deploying: ")
-	var ipAddress string
-	_, err = fmt.Scan(&ipAddress)
-	if err != nil {
-		return err
-	}
-	config.UserIPAddress = ipAddress
-	fmt.Println("Enter a name for the s3 bucket that will hold your osquery logs. \n" +
-		"Remeber;  S3 bucket names must be globally unique: ")
-	var logBucketName string
-	fmt.Scan(&logBucketName)
-	if err != nil {
-		return err
-	}
-	config.SgtOsqueryResultsBucketName = logBucketName
-	fmt.Println("Enter a name for the s3 bucket that will hold your server configuration \n" +
-		"Remeber;  S3 bucket names must be globally unique: ")
-	var configBucket string
-	_, err = fmt.Scan(&configBucket)
-	if err != nil {
-		return err
-	}
-	config.SgtConfigBucketName = configBucket
-	fmt.Println("Enter the domain you will be using for your SGT server. \n" +
-		"Note:  This MUST be a domain which you have previously registered or are managing through" +
-		"aws. \n  This will be used to create a subdomain for the SGT TLS endpoint")
-	var domain string
-	_, err = fmt.Scan(&domain)
-	if err != nil {
-		return err
-	}
-	config.Domain = domain
-	fmt.Println("Enter a subdomain to use as the endpoint.  This will be prepended to the \n" +
-		"domain you provided as a subdomain")
-	var subdomain string
-	_, err = fmt.Scan(&subdomain)
-	if err != nil {
-		return err
-	}
-	config.Subdomain = subdomain
-	fmt.Println("Enter the name of your aws keypair.  This is used to access ec2 instances if" +
-		"the need \n should ever arise (it shouldn't).\n" +
-		"NOTE:  This is the name of the keypair EXCLUDING the .pem flie name and it must already exist in aws")
-	var keypair string
-	_, err = fmt.Scan(&keypair)
-	if err != nil {
-		return err
-	}
-	config.AwsKeypair = keypair
-	fmt.Println("Enter the name of the full ssl certificate chain bundle you will be using for \n" +
-		"your SGT server.  EG - full_chain.pem : ")
-	var fullChain string
-	_, err = fmt.Scan(&fullChain)
-	if err != nil {
-		return err
-	}
-	config.FullSslCertchain = fullChain
-	fmt.Println("Enter the name of the private key for your ssl certificate.  Eg - privkey.pem: ")
-	var privKey string
-	_, err = fmt.Scan(&privKey)
-	if err != nil {
-		return err
-	}
-	config.SslPrivateKey = privKey
-	fmt.Println("Enter the node secret you will use to enroll your endpoints with the SGT server\n" +
-		"This secret will be used by each endpoint to authenticate to your server: ")
-	var nodeSecret string
-	_, err = fmt.Scan(&nodeSecret)
-	if err != nil {
-		return err
-	}
-	config.SgtNodeSecret = nodeSecret
-	fmt.Println("Enter the app secret key which will be used to generate session tokens when \n" +
-		"interacting with the API as an authenticated end-user.  Make this long, random and complex: ")
-	var appSecret string
-	_, err = fmt.Scan(&appSecret)
-	if err != nil {
-		return err
-	}
-	config.SgtAppSecret = appSecret
-	fmt.Println("Congratulations, you've successfully configured your SGT deployment! \n" +
-		"That wasn't so bad, was it? \n" +
-		"You're now ready to do the actual deployment")
-	fmt.Println("If you'd like to continue and do the actual deployment, you may continue by\n" +
-		"entering 'Y' at the next prompt.  If you'd like to pause, don't worry! \n" +
-		"next time you're ready to continue, just run ./sgt -deploy -env $your_deployment_name")
-	fmt.Println("Would you like to proceed with deployment? Y/N")
-	d, err := json.Marshal(config)
-	fn := fmt.Sprintf("terraform/%s/%s.json", envName, envName)
-	err = ioutil.WriteFile(fn, d, 0644)
-	var ans string
-	_, err = fmt.Scan(&ans)
-	confirmStrings := []string{"y", "Y", "yes", "YES"}
-	var deploy bool
-	for _, i := range confirmStrings {
-		if strings.Contains(i, ans) {
-			deploy = true
-			break
-		}
-	}
-	if deploy {
-		curdir, err := os.Getwd()
-		if err != nil {
-			logger.Error(err)
-			return err
-		}
-		err = DeployAll(config, curdir, config.Environment)
-		if err != nil {
-			logger.Fatal(err)
-		}
-	}
-	return nil
-}
-
-//UserAwsCredFile returns a users aws credential file from their home dir
+// UserAwsCredFile returns a users aws credential file from their home dir
 func UserAwsCredFile() (string, error) {
 	usr, err := user.Current()
 	if err != nil {
@@ -761,31 +167,9 @@ func UserAwsCredFile() (string, error) {
 	return credfile, nil
 }
 
-//TState struct for terraform state
-type TState struct {
-	Version          int        `json:"version"`
-	TerraformVersion string     `json:"terraform_version"`
-	Serial           int        `json:"serial"`
-	Lineage          string     `json:"lineage"`
-	Modules          []TFModule `json:"modules"`
-}
-
-//TFModule struct for terrform modules in tfstates
-type TFModule struct {
-	Path    []string            `json:"path"`
-	Outputs map[string]TFOutput `json:"outputs"`
-}
-
-//TFOutput struct for terraform outputs from tfstate files
-type TFOutput struct {
-	Sensitive bool   `json:"sensitive"`
-	Type      string `json:"type"`
-	Value     string `json:"value"`
-}
-
-//DeployDefaultPacks deploys default packs for an environment if they exist, otherwise deploys
-//from normal defaults
-func DeployDefaultPacks(config DeploymentConfig, environ string) error {
+// osqueryDefaultPacks deploys default packs for an environment if they exist, otherwise deploys
+// from normal defaults
+func osqueryDefaultPacks(config DeploymentConfig, environ string) error {
 	var files []string
 
 	//if environ specific dir exists in packs, deploy those.  Otherwise use defaults
@@ -794,15 +178,13 @@ func DeployDefaultPacks(config DeploymentConfig, environ string) error {
 		logger.Info("using default packs")
 		files, err = filepath.Glob("packs/*")
 		if err != nil {
-			logger.Error(err)
 			return err
 		}
 	} else {
-		logger.Infof("Environment specific folder found for: %s\nUsing %s query packs\n", environ, environ)
+		logger.Infof("Environment specific folder found for: %[1]s\nUsing %[1]s query packs\n", environ)
 		path := fmt.Sprintf("packs/%s/*", environ)
 		files, err = filepath.Glob(path)
 		if err != nil {
-			logger.Error(err)
 			return err
 		}
 	}
@@ -815,22 +197,19 @@ func DeployDefaultPacks(config DeploymentConfig, environ string) error {
 			helperPack := helpers.OsqueryPack{}
 			s, err := helpers.CleanPack(filename)
 			if err != nil {
-				logger.Error(err)
+				return err
 			}
 			file := strings.NewReader(s)
 			if err != nil {
-				logger.Error(err)
 				return err
 			}
 			decoder := json.NewDecoder(file)
 			err = decoder.Decode(&helperPack)
 			if err != nil {
-				logger.Error(err)
 				return err
 			}
 			credfile, err := UserAwsCredFile()
 			if err != nil {
-				logger.Error(err)
 				return err
 			}
 			dynDBInstance := auth.CrendentialedDbInstance(credfile, config.AWSProfile)
@@ -849,7 +228,6 @@ func DeployDefaultPacks(config DeploymentConfig, environ string) error {
 			pack.PackName = strings.Split(filename, ".")[0]
 			err = dyndb.UpsertPack(pack, dynDBInstance, mu)
 			if err != nil {
-				logger.Error(err)
 				return err
 			}
 		}
@@ -858,8 +236,8 @@ func DeployDefaultPacks(config DeploymentConfig, environ string) error {
 	return nil
 }
 
-//DeployDefaultConfigs deploys default configs for env
-func DeployDefaultConfigs(config DeploymentConfig, environ string) error {
+// osqueryDefaultConfigs deploys default configs for env
+func osqueryDefaultConfigs(config DeploymentConfig, environ string) error {
 	var files []string
 
 	//if environ specific dir exists in packs, deploy those.  Otherwise use defaults
@@ -871,16 +249,14 @@ func DeployDefaultConfigs(config DeploymentConfig, environ string) error {
 		environ = "defaults"
 		envSpecificConfigs = true
 		if err != nil {
-			logger.Error(err)
 			return err
 		}
 	} else {
-		logger.Infof("Environment specific folder found for: %s\nUsing %s configs\n", environ, environ)
+		logger.Infof("Environment specific folder found for: %[1]s\nUsing %[1]s configs\n", environ)
 		path := fmt.Sprintf("osquery_configs/%s/*", environ)
 		envSpecificConfigs = true
 		files, err = filepath.Glob(path)
 		if err != nil {
-			logger.Error(err)
 			return err
 		}
 	}
@@ -905,17 +281,13 @@ func DeployDefaultConfigs(config DeploymentConfig, environ string) error {
 		namedConfig := osq_types.OsqueryNamedConfig{}
 		defer file.Close()
 		if err != nil {
-			logger.Error(err)
 			return err
-
 		}
 		config := osq_types.OsqueryConfig{}
 		decoder := json.NewDecoder(file)
 		err = decoder.Decode(&config)
 		if err != nil {
-			logger.Error(err)
 			return err
-
 		}
 		//fmt.Printf("%s", config.Packs)
 		namedConfig.Config_name = strings.Split(filename, ".")[0]
@@ -932,10 +304,9 @@ func DeployDefaultConfigs(config DeploymentConfig, environ string) error {
 		var pl []string
 		err = json.Unmarshal(*config.Packs, &pl)
 		if err != nil {
-			logger.Error(err)
 			return err
-
 		}
+
 		namedConfig.PackList = pl
 		//blank out config packs since the options config doesn't have a packs kv
 		config.Packs = nil
@@ -957,7 +328,6 @@ func CreateDirIfNotExists(path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		err = os.Mkdir(path, 0755)
 		if err != nil {
-			logger.Error(err)
 			return err
 		}
 	}
@@ -970,20 +340,16 @@ func FindAndReplace(filename, original, replacement string) error {
 	perms := fileinfo.Mode()
 	input, err := ioutil.ReadFile(filename)
 	if err != nil {
-		logger.Error(err)
 		return err
 	}
+
 	output := bytes.Replace(input, []byte(original), []byte(replacement), -1)
 
-	if err = ioutil.WriteFile(filename, output, perms); err != nil {
-		logger.Error(err)
-		return err
-	}
-	return nil
+	return ioutil.WriteFile(filename, output, perms)
 }
 
-//GenerateEndpointDeployScripts generates endpoint scripts for installation
-func GenerateEndpointDeployScripts(config DeploymentConfig, environ string) error {
+// generateEndpointDeployScripts generates endpoint scripts for installation
+func generateEndpointDeployScripts(config DeploymentConfig, environ string) error {
 	logger.Infof("Updating endpoint deployments scripts for %s environment...\n", environ)
 
 	// make sure all dirs are created
@@ -1008,19 +374,19 @@ func GenerateEndpointDeployScripts(config DeploymentConfig, environ string) erro
 		return err
 	}
 	//copy example config files
-	err = CopyFile(filepath.Join("endpoints", "deploy", "example_environment", "Mac", "mac_deploy.sh"),
+	err = copyFile(filepath.Join("endpoints", "deploy", "example_environment", "Mac", "mac_deploy.sh"),
 		filepath.Join("endpoints", "deploy", environ, "Mac", "mac_deploy.sh"))
 	if err != nil {
 		logger.Error(err)
 		return err
 	}
-	CopyFile(filepath.Join("endpoints", "deploy", "example_environment", "Windows", "windows_deploy.ps1"),
+	copyFile(filepath.Join("endpoints", "deploy", "example_environment", "Windows", "windows_deploy.ps1"),
 		filepath.Join("endpoints", "deploy", environ, "Windows", "windows_deploy.ps1"))
 	if err != nil {
 		logger.Error(err)
 		return err
 	}
-	CopyFile(filepath.Join("endpoints", "deploy", "example_environment", "Linux", "linux_deploy.sh"),
+	copyFile(filepath.Join("endpoints", "deploy", "example_environment", "Linux", "linux_deploy.sh"),
 		filepath.Join("endpoints", "deploy", environ, "Linux", "linux_deploy.sh"))
 	if err != nil {
 		logger.Error(err)

--- a/handlers/deploy/destroy.go
+++ b/handlers/deploy/destroy.go
@@ -1,0 +1,53 @@
+package deploy
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/oktasecuritylabs/sgt/logger"
+)
+
+// DestroyAllComponents destroys all components, in reverse order
+func DestroyAllComponents(envName string) error {
+	for i := len(DeployOrder) - 1; i >= 0; i-- {
+		if err := destroyAWSComponent(DeployOrder[i], envName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DestroyComponent is a wrapper to match the `deploy.Component` interface style
+func DestroyComponent(component, envName string) error {
+	return destroyAWSComponent(component, envName)
+}
+
+// destroyAWSComponent destroys aws components
+// This includes: VPC, Datastore, Firehose, Autoscaling, Secrets, Elasticsearch, S3
+func destroyAWSComponent(component, envName string) error {
+
+	// Change back to the top level directory after each component deploy
+	cachedCurDir, _ := os.Getwd()
+	defer os.Chdir(cachedCurDir)
+
+	spin.Start()
+	defer spin.Stop()
+
+	logger.Infof("Destroying %s...", component)
+
+	err := os.Chdir(fmt.Sprintf("terraform/%s/%s", envName, component))
+	if err != nil {
+		return err
+	}
+
+	args := fmt.Sprintf("terraform destroy -force -var-file=../%s.json", envName)
+	logger.Info(args)
+
+	cmd := exec.Command("bash", "-c", args)
+	stdoutStderr, err := cmd.CombinedOutput()
+
+	logger.Info(string(stdoutStderr))
+
+	return err
+}

--- a/handlers/deploy/wizard.go
+++ b/handlers/deploy/wizard.go
@@ -1,0 +1,137 @@
+package deploy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/oktasecuritylabs/sgt/handlers/helpers"
+)
+
+// Wizard walks through setting up an environment config and deploys
+func Wizard() error {
+	config := DeploymentConfig{}
+	fmt.Print("Enter new environment name.  This is typically something like" +
+		"'Dev' or 'Prod' or 'Testing, but can be anything you want it to be: ")
+	//envName, err := reader.ReadString('\n')
+	var envName string
+	_, err := fmt.Scan(&envName)
+	if err != nil {
+		return err
+	}
+	err = CreateDeployDirectory(envName)
+	if err != nil {
+		return err
+	}
+	config.Environment = envName
+	fmt.Println("Enter the name for the aws profile you'd like to use to deploy this environment \n" +
+		"if you've never created a profile before, you can read more about how to do this here\n" +
+		"http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html \n" +
+		"a 'default' profile is created if you've installed and configured the aws cli: ")
+	var profile string
+	_, err = fmt.Scan(&profile)
+	if err != nil {
+		return err
+	}
+	config.AWSProfile = profile
+	fmt.Println("Enter an ipaddress or cidr block for access to your elasticsearch cluster. \n" +
+		"Note:  This should probably be your current IP address, as you will need to be able to access \n" +
+		"elasticsearch via API to create the proper indices and mappings when deploying: ")
+	var ipAddress string
+	_, err = fmt.Scan(&ipAddress)
+	if err != nil {
+		return err
+	}
+	config.UserIPAddress = ipAddress
+	fmt.Println("Enter a name for the s3 bucket that will hold your osquery logs. \n" +
+		"Remeber;  S3 bucket names must be globally unique: ")
+	var logBucketName string
+	_, err = fmt.Scan(&logBucketName)
+	if err != nil {
+		return err
+	}
+	config.SgtOsqueryResultsBucketName = logBucketName
+	fmt.Println("Enter a name for the s3 bucket that will hold your server configuration \n" +
+		"Remeber;  S3 bucket names must be globally unique: ")
+	var configBucket string
+	_, err = fmt.Scan(&configBucket)
+	if err != nil {
+		return err
+	}
+	config.SgtConfigBucketName = configBucket
+	fmt.Println("Enter the domain you will be using for your SGT server. \n" +
+		"Note:  This MUST be a domain which you have previously registered or are managing through" +
+		"aws. \n  This will be used to create a subdomain for the SGT TLS endpoint")
+	var domain string
+	_, err = fmt.Scan(&domain)
+	if err != nil {
+		return err
+	}
+	config.Domain = domain
+	fmt.Println("Enter a subdomain to use as the endpoint.  This will be prepended to the \n" +
+		"domain you provided as a subdomain")
+	var subdomain string
+	_, err = fmt.Scan(&subdomain)
+	if err != nil {
+		return err
+	}
+	config.Subdomain = subdomain
+	fmt.Println("Enter the name of your aws keypair.  This is used to access ec2 instances if" +
+		"the need \n should ever arise (it shouldn't).\n" +
+		"NOTE:  This is the name of the keypair EXCLUDING the .pem flie name and it must already exist in aws")
+	var keypair string
+	_, err = fmt.Scan(&keypair)
+	if err != nil {
+		return err
+	}
+	config.AwsKeypair = keypair
+	fmt.Println("Enter the name of the full ssl certificate chain bundle you will be using for \n" +
+		"your SGT server.  EG - full_chain.pem : ")
+	var fullChain string
+	_, err = fmt.Scan(&fullChain)
+	if err != nil {
+		return err
+	}
+	config.FullSslCertchain = fullChain
+	fmt.Println("Enter the name of the private key for your ssl certificate.  Eg - privkey.pem: ")
+	var privKey string
+	_, err = fmt.Scan(&privKey)
+	if err != nil {
+		return err
+	}
+	config.SslPrivateKey = privKey
+	fmt.Println("Enter the node secret you will use to enroll your endpoints with the SGT server\n" +
+		"This secret will be used by each endpoint to authenticate to your server: ")
+	var nodeSecret string
+	_, err = fmt.Scan(&nodeSecret)
+	if err != nil {
+		return err
+	}
+	config.SgtNodeSecret = nodeSecret
+	fmt.Println("Enter the app secret key which will be used to generate session tokens when \n" +
+		"interacting with the API as an authenticated end-user.  Make this long, random and complex: ")
+	var appSecret string
+	_, err = fmt.Scan(&appSecret)
+	if err != nil {
+		return err
+	}
+	config.SgtAppSecret = appSecret
+	fmt.Println("Congratulations, you've successfully configured your SGT deployment! \n" +
+		"That wasn't so bad, was it? \n" +
+		"You're now ready to do the actual deployment")
+	fmt.Println("If you'd like to continue and do the actual deployment, you may continue by\n" +
+		"entering 'Y' at the next prompt.  If you'd like to pause, don't worry! \n" +
+		"next time you're ready to continue, just run ./sgt -deploy -env $your_deployment_name")
+	d, err := json.Marshal(config)
+	fn := fmt.Sprintf("terraform/%s/%s.json", envName, envName)
+	err = ioutil.WriteFile(fn, d, 0644)
+	if err != nil {
+		return err
+	}
+
+	if helpers.ConfirmAction("Would you like to proceed with deployment?") {
+		err = AllComponents(config, envName)
+	}
+
+	return err
+}

--- a/handlers/helpers/helpers.go
+++ b/handlers/helpers/helpers.go
@@ -2,6 +2,8 @@ package helpers
 
 import (
 	"bufio"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,10 +11,73 @@ import (
 	"github.com/oktasecuritylabs/sgt/logger"
 )
 
+// GetValueFromUser prompts the user to provide a value
+func GetValueFromUser(prompt string) (string, error) {
+
+	if prompt == "" {
+		prompt = "Please provide a value"
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%s:\n", prompt)
+
+	value, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", errors.New("a non-empty value name must be supplied")
+	}
+
+	return value, nil
+}
+
+// ConfirmAction scans user input for a yes or no confirmation
+func ConfirmAction(prompt string) bool {
+	reader := bufio.NewReader(os.Stdin)
+
+	// The input gets lower-cased so only need to iterate on these options
+	confirmStrings := []string{"y", "yes"}
+	denyStrings := []string{"n", "no"}
+
+	for tries := 0; tries < 3; tries++ {
+		fmt.Printf("%s [y/n]: ", prompt)
+
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			logger.Error(err)
+			return false
+		}
+
+		response = strings.ToLower(strings.TrimSpace(response))
+		if len(response) == 0 {
+			continue
+		}
+
+		// Check for approvals
+		for _, i := range confirmStrings {
+			if i == response {
+				return true
+			}
+		}
+
+		// Check for denials
+		for _, i := range denyStrings {
+			if i == response {
+				return false
+			}
+		}
+	}
+
+	return false
+}
+
 func CleanPack(filename string) (string, error) {
 	file, err := os.Open(filepath.Join("packs", filename))
 	if err != nil {
-		logger.Error(err)
+		return "", err
 	}
 	defer file.Close()
 	scanner := bufio.NewScanner(file)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,21 +1,41 @@
 package logger
 
 import (
+	"bytes"
 	"os"
 
 	"github.com/sirupsen/logrus"
 )
 
-var logger = logrus.New()
+var logger *logrus.Logger
+
+// A simple hook to allow for logging to stdout and a file at the same time
+type stdOutHook struct{}
+
+func (hook *stdOutHook) Fire(entry *logrus.Entry) error {
+	b := &bytes.Buffer{}
+	b.WriteString(entry.Message)
+	b.WriteByte('\n')
+	os.Stdout.Write(b.Bytes())
+	return nil
+}
+
+func (hook *stdOutHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
 
 func init() {
+	logger = logrus.New()
 	file, err := os.OpenFile("/var/log/osquery-sgt.log", os.O_CREATE|os.O_WRONLY, 0666)
+	logger.SetLevel(logrus.InfoLevel)
 	if err == nil {
+		// Add a hook so stdout also contains log messages along with the output file
+		// This is helpful for debugging in an active console
+		logger.Hooks.Add(&stdOutHook{})
 		logger.Out = file
 	} else {
 		logger.Info("Failed to log to file, using default stderr")
 	}
-	logger.Level = logrus.InfoLevel
 }
 
 func Info(args ...interface{}) {
@@ -45,7 +65,3 @@ func Fatal(args ...interface{}) {
 func WithFields(args ...interface{}) *logrus.Entry {
 	return logger.WithFields(logrus.Fields{})
 }
-
-//func Warnf(args ...interface{}) {
-//logger.Warnf(args...)
-//}

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/oktasecuritylabs/sgt/handlers/api"
+	"github.com/oktasecuritylabs/sgt/handlers/auth"
+	"github.com/oktasecuritylabs/sgt/handlers/distributed"
+	"github.com/oktasecuritylabs/sgt/handlers/node"
+	"github.com/urfave/negroni"
+)
+
+// Serve will create the server listen
+func Serve() error {
+	router := mux.NewRouter()
+	//node endpoint
+	nodeAPI := router.PathPrefix("/node").Subrouter()
+	nodeAPI.Path("/configure").HandlerFunc(node.NodeConfigureRequest)
+	nodeAPI.Path("/enroll").HandlerFunc(node.NodeEnrollRequest)
+	//protect with uiAuth
+	//Configuration (management) endpoint
+	apiRouter := mux.NewRouter().PathPrefix("/api/v1/configuration").Subrouter()
+
+	//apiRouter.HandleFunc("/config", api.APIConfigurationRequest)
+	apiRouter.HandleFunc("/config/{config_name}", api.ConfigurationRequest)
+	//Nodes
+	apiRouter.HandleFunc("/nodes", api.GetNodes).Methods("GET")
+	apiRouter.HandleFunc("/nodes/{node_key}", api.ConfigureNode).Methods("POST", "GET")
+	apiRouter.HandleFunc("/nodes/{node_key}/approve", api.ApproveNode).Methods("POST")
+	//apiRouter.HandleFunc("/nodes/approve/_bulk", api.Placeholder).Methods("POST)
+	//Packs
+	apiRouter.HandleFunc("/packs", api.GetQueryPacks).Methods("GET")
+	apiRouter.HandleFunc("/packs/search/{search_string}", api.SearchQueryPacks).Methods("GET")
+	apiRouter.HandleFunc("/packs/{pack_name}", api.ConfigurePack).Methods("POST")
+	//PackQueries
+	apiRouter.HandleFunc("/packqueries", api.GetPackQueries).Methods("GET")
+	apiRouter.HandleFunc("/packqueries/{query_name}", api.ConfigurePackQuery)
+	apiRouter.HandleFunc("/packqueries/search/{search_string}", api.SearchPackQueries)
+	apiRouter.HandleFunc("/distributed/add", distributed.DistributedQueryAdd)
+	//Enforce uiAuth for all our api configuration endpoints
+	router.PathPrefix("/api/v1/configuration").Handler(negroni.New(
+		negroni.NewRecovery(),
+		negroni.HandlerFunc(auth.AnotherValidation),
+		negroni.Wrap(apiRouter),
+	))
+	//token
+	router.HandleFunc("/api/v1/get-token", auth.GetTokenHandler)
+	//Distributed endpoint
+	distributedRouter := mux.NewRouter().PathPrefix("/distributed").Subrouter()
+	distributedRouter.HandleFunc("/read", distributed.DistributedQueryRead)
+	distributedRouter.HandleFunc("/write", distributed.DistributedQueryWrite)
+	//auth for distributed read/write
+	router.PathPrefix("/distributed").Handler(negroni.New(
+		negroni.NewRecovery(),
+		negroni.HandlerFunc(auth.ValidNodeKey),
+		negroni.Wrap(distributedRouter),
+	))
+	//Enforce auth for all our api configuration endpoints
+	router.PathPrefix("/api/v1/configuration").Handler(negroni.New(
+		negroni.NewRecovery(),
+		negroni.HandlerFunc(auth.AnotherValidation),
+		negroni.Wrap(apiRouter),
+	))
+	err := http.ListenAndServeTLS(":443",
+		"fullchain.pem", "privkey.pem", handlers.LoggingHandler(os.Stdout, router))
+	return err
+}

--- a/sgt.go
+++ b/sgt.go
@@ -1,321 +1,302 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
+	"sort"
+	"strings"
 
-	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
-	"github.com/oktasecuritylabs/sgt/handlers/api"
 	"github.com/oktasecuritylabs/sgt/handlers/auth"
 	"github.com/oktasecuritylabs/sgt/handlers/deploy"
-	"github.com/oktasecuritylabs/sgt/handlers/distributed"
-	"github.com/oktasecuritylabs/sgt/handlers/node"
+	"github.com/oktasecuritylabs/sgt/handlers/helpers"
 	"github.com/oktasecuritylabs/sgt/logger"
-	"github.com/urfave/negroni"
+	"github.com/oktasecuritylabs/sgt/server"
 )
 
-func server() {
-	router := mux.NewRouter()
-	//node endpoint
-	nodeAPI := router.PathPrefix("/node").Subrouter()
-	nodeAPI.Path("/configure").HandlerFunc(node.NodeConfigureRequest)
-	nodeAPI.Path("/enroll").HandlerFunc(node.NodeEnrollRequest)
-	//protect with uiAuth
-	//Configuration (management) endpoint
-	apiRouter := mux.NewRouter().PathPrefix("/api/v1/configuration").Subrouter()
+const (
+	runServer    = "server"
+	runWizard    = "wizard"
+	runNewDeploy = "new-deployment"
+	createUser   = "create-user"
+	runDeploy    = "deploy"
+	runDestroy   = "destroy"
+)
 
-	//apiRouter.HandleFunc("/config", api.APIConfigurationRequest)
-	apiRouter.HandleFunc("/config/{config_name}", api.ConfigurationRequest)
-	//Nodes
-	apiRouter.HandleFunc("/nodes", api.GetNodes).Methods("GET")
-	apiRouter.HandleFunc("/nodes/{node_key}", api.ConfigureNode).Methods("POST", "GET")
-	apiRouter.HandleFunc("/nodes/{node_key}/approve", api.ApproveNode).Methods("POST")
-	//apiRouter.HandleFunc("/nodes/approve/_bulk", api.Placeholder).Methods("POST)
-	//Packs
-	apiRouter.HandleFunc("/packs", api.GetQueryPacks).Methods("GET")
-	apiRouter.HandleFunc("/packs/search/{search_string}", api.SearchQueryPacks).Methods("GET")
-	apiRouter.HandleFunc("/packs/{pack_name}", api.ConfigurePack).Methods("POST")
-	//PackQueries
-	apiRouter.HandleFunc("/packqueries", api.GetPackQueries).Methods("GET")
-	apiRouter.HandleFunc("/packqueries/{query_name}", api.ConfigurePackQuery)
-	apiRouter.HandleFunc("/packqueries/search/{search_string}", api.SearchPackQueries)
-	apiRouter.HandleFunc("/distributed/add", distributed.DistributedQueryAdd)
-	//Enforce uiAuth for all our api configuration endpoints
-	router.PathPrefix("/api/v1/configuration").Handler(negroni.New(
-		negroni.NewRecovery(),
-		negroni.HandlerFunc(auth.AnotherValidation),
-		negroni.Wrap(apiRouter),
-	))
-	//token
-	router.HandleFunc("/api/v1/get-token", auth.GetTokenHandler)
-	//Distributed endpoint
-	distributedRouter := mux.NewRouter().PathPrefix("/distributed").Subrouter()
-	distributedRouter.HandleFunc("/read", distributed.DistributedQueryRead)
-	distributedRouter.HandleFunc("/write", distributed.DistributedQueryWrite)
-	//auth for distributed read/write
-	router.PathPrefix("/distributed").Handler(negroni.New(
-		negroni.NewRecovery(),
-		negroni.HandlerFunc(auth.ValidNodeKey),
-		negroni.Wrap(distributedRouter),
-	))
-	//Enforce auth for all our api configuration endpoints
-	router.PathPrefix("/api/v1/configuration").Handler(negroni.New(
-		negroni.NewRecovery(),
-		negroni.HandlerFunc(auth.AnotherValidation),
-		negroni.Wrap(apiRouter),
-	))
-	webServer := http.ListenAndServeTLS(":443",
-		"fullchain.pem", "privkey.pem", handlers.LoggingHandler(os.Stdout, router))
-	log.Panic("web server", webServer)
+var commands = map[string]string{
+	runServer:    "Run in server mode, launching the TLS server",
+	runWizard:    "Run deployment configuration wizard",
+	runNewDeploy: "Created new deployment",
+	createUser:   "Create a new user",
+	runDeploy:    "Deploy new sgt environment",
+	runDestroy:   "Destroy existing infrastructure",
 }
 
-func main() {
-	credentialsFile := flag.String("credentialsFile", "~/.aws/credentials", "path to credentials file")
-	profile := flag.String("profile", "", "profile name")
-	createuser := flag.Bool("create_user", false, "create new user")
-	deployFlag := flag.Bool("deploy", false, "deploy new sgt environment")
-	//config_file := flag.String("configfile", "", "config file for deploy")
-	vpc := flag.Bool("vpc", false, "deploy VPC component")
-	datastore := flag.Bool("datastore", false, "deploy datastore component")
-	elasticsearch := flag.Bool("elasticsearch", false, "deploy elasticsearch component")
-	firehose := flag.Bool("firehose", false, "deploy firehose component")
-	s3 := flag.Bool("s3", false, "deploy s3 component")
-	autoscaling := flag.Bool("autoscaling", false, "deploy autoscaling component")
-	secrets := flag.Bool("secrets", false, "deploy app and node secrets")
-	all := flag.Bool("all", false, "deploy all components [vpc, elasticsearch, firehose, s3, autoscaling")
-	environ := flag.String("env", "", "deployment environment name")
-	username := flag.String("username", "", "username")
-	role := flag.String("role", "user", "user role")
-	destroy := flag.Bool("destroy", false, "destroy existing infrastructure")
-	newDeploy := flag.Bool("new-deployment", false, "created new deployment")
-	wizard := flag.Bool("wizard", false, "Run deployment configuration wizard")
-	packs := flag.Bool("packs", false, "update packs")
-	configs := flag.Bool("configs", false, "update osquery configs")
-	endpoints := flag.Bool("endpoints", false, "update endpoint config scripts")
-	flag.Parse()
-	if *wizard {
-		err := deploy.DeployWizard()
+func printHelp(err interface{}) {
+	// Print any optional errors passed
+	if err != nil {
+		logger.Error(err)
+	}
+
+	fmt.Print("usage: sgt <command> [<args>]\n\n")
+	fmt.Printf("Commands:\n%s\n", formatSection(commands))
+	os.Exit(0)
+}
+
+func formatSection(commands map[string]string) string {
+	keys := make([]string, 0, len(commands))
+	maxLen := 0
+	for key := range commands {
+		if len(key) > maxLen {
+			maxLen = len(key)
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+	for _, key := range keys {
+		commandHelp, ok := commands[key]
+		if !ok {
+			logger.Fatal(fmt.Sprintf("command not found: %s", key))
+		}
+
+		key = fmt.Sprintf("%s%s", key, strings.Repeat(" ", maxLen-len(key)))
+		buf.WriteString(fmt.Sprintf("    %s    %s\n", key, commandHelp))
+	}
+
+	return buf.String()
+}
+
+// New type for a list of deploy commands
+type componentChoices []string
+
+// Implement String() from the flag.Value interface
+func (s *componentChoices) String() string {
+	return fmt.Sprintf("%v", *s)
+}
+
+// Implement Set(string) from the flag.Value interface
+func (s *componentChoices) Set(value string) error {
+	*s = strings.Split(value, ",")
+	return nil
+}
+
+// validateChoices takes one list of acceptable options and a second list
+// of provided options and returns an error if an invalid options are selected.
+// If all options are valid, this returns a de-duplicated map of them
+func validateChoices(validOpts, chosenOpts []string) ([]string, error) {
+
+	if chosenOpts == nil {
+		return nil, errors.New("at least one component to deploy must be supplied")
+	}
+
+	chosenOptsMap := make(map[string]bool)
+	for _, k := range chosenOpts {
+		chosenOptsMap[k] = true
+	}
+
+	validOptsMap := make(map[string]bool)
+	for _, k := range validOpts {
+		validOptsMap[k] = true
+	}
+
+	var chosenOptions []string
+	for k := range chosenOptsMap {
+		if _, ok := validOptsMap[k]; !ok {
+			return nil, fmt.Errorf("invalid deploy component specified: %s", k)
+		}
+		chosenOptions = append(chosenOptions, k)
+	}
+
+	return chosenOptions, nil
+}
+
+func runSGT() error {
+
+	if len(os.Args) == 1 {
+		printHelp(nil)
+	}
+
+	switch os.Args[1] {
+	case runWizard:
+		err := deploy.Wizard()
 		if err != nil {
 			logger.Fatal(err)
 		}
-		return
-	}
-	if *newDeploy {
-		envName := ""
-		if len(os.Args[0]) > 0 {
-			envName = os.Args[0]
-			if len(envName) > 0 {
-				err := deploy.CreateDeployDirectory(envName)
-				if err != nil {
-					logger.Error(err)
-					os.Exit(1)
-				}
-			}
 
+	case runNewDeploy:
+		// Create a FlagSet for the new-deployment command
+		newDeployCommand := flag.NewFlagSet(runNewDeploy, flag.ExitOnError)
+		envFlag := newDeployCommand.String("env", "", "Deployment environment name")
+
+		newDeployCommand.Parse(os.Args[2:])
+
+		envName := strings.TrimSpace(*envFlag)
+		if envName == "" {
+			var err error
+			if envName, err = helpers.GetValueFromUser("Enter new environment name"); err != nil {
+				newDeployCommand.Usage()
+				return err
+			}
+		}
+
+		if err := deploy.CreateDeployDirectory(envName); err != nil {
+			return err
+		}
+
+		logger.Warn(fmt.Sprintf("New deployment created. Remember to go change the defaults in your terraform/%[1]s/%[1]s.json files!", envName))
+
+	case createUser:
+		// Create a FlagSet for the create-user command
+		createUserCommand := flag.NewFlagSet("create-user", flag.ExitOnError)
+		usernameFlag := createUserCommand.String("username", "", "username to create")
+		credFileFlag := createUserCommand.String("credentials-file", "~/.aws/credentials",
+			"path to aws credentials file (default: ~/.aws/credentials)")
+		profileFlag := createUserCommand.String("profile", "", "aws profile name")
+		roleFlag := createUserCommand.String("role", "user", "role to be used (default: user)")
+
+		createUserCommand.Parse(os.Args[2:])
+
+		// invalid is an anonymous helper function to validate the length of the input
+		invalid := func(v *string) bool {
+			return len(strings.TrimSpace(*v)) < 4
+		}
+
+		if invalid(usernameFlag) {
+			createUserCommand.Usage()
+			return errors.New("username required, please pass username via -username flag")
+		}
+		if invalid(credFileFlag) {
+			createUserCommand.Usage()
+			return errors.New("aws credentials file required, please pass via -credentialsFile flag")
+		}
+		if invalid(profileFlag) {
+			createUserCommand.Usage()
+			return errors.New("aws profile name required, please pass via -profile flag")
+		}
+
+		auth.NewUser(*credFileFlag, *profileFlag, *usernameFlag, *roleFlag)
+
+	case runDeploy:
+
+		validComponentOptions := append(deploy.DeployOrder, deploy.OsqueryOpts...)
+		componentList := strings.Join(validComponentOptions, ", ")
+
+		// Create a FlagSet for the deploy command
+		deployCommand := flag.NewFlagSet(runDeploy, flag.ExitOnError)
+		envFlag := deployCommand.String("env", "", "Deployment environment name")
+		allFlag := deployCommand.Bool("all", false, fmt.Sprintf("Deploy all components [%s]", componentList))
+
+		// Create a list of components to deploy that can be chosen from
+		var chosenDeployOptions componentChoices
+		deployCommand.Var(&chosenDeployOptions, "components",
+			fmt.Sprintf("A comma-seperated (without spaces) list of components to deploy. Choices are: %s",
+				componentList))
+
+		deployCommand.Parse(os.Args[2:])
+		envName := *envFlag
+		if envName == "" {
+			var err error
+			if envName, err = helpers.GetValueFromUser("Enter new environment name"); err != nil {
+				deployCommand.Usage()
+				return err
+			}
+		}
+
+		chosenOptions, err := validateChoices(validComponentOptions, chosenDeployOptions)
+		if err != nil {
+			deployCommand.Usage()
+			return err
+		}
+
+		log.Printf("Beginning deployment to %[1]s using configuration specified in %[1]s.json", envName)
+
+		config, err := deploy.ParseDeploymentConfig(envName)
+		if err != nil {
+			return err
+		}
+
+		if *allFlag {
+			if err = deploy.AllComponents(config, envName); err != nil {
+				return err
+			}
 		} else {
-			reader := bufio.NewReader(os.Stdin)
-			fmt.Print("Enter new environment name: ")
-			envName, err := reader.ReadString('\n')
-			if err != nil {
-				logger.Error(err)
-				os.Exit(1)
-			}
-			if len(envName) > 0 {
-				err = deploy.CreateDeployDirectory(envName)
-				if err != nil {
-					logger.Error(err)
-					os.Exit(1)
-				}
-			}
-		}
-		logger.Warn("New deployment created.  Remember to go change the defaults in your $environment.json files!")
-		return
-	}
-	if *createuser || *deployFlag || *destroy {
-		if *createuser {
-			if !(len(*username) > 4) {
-				flag.Usage()
-				logger.Error("username required, please pass username via -username flag")
-				os.Exit(0)
-			}
-			if !(len(*credentialsFile) > 4) {
-				flag.Usage()
-				logger.Error("aws credentials file required, please pass via -credentialsFile flag")
-				os.Exit(0)
-			}
-			if !(len(*profile) > 4) {
-				flag.Usage()
-				logger.Error("aws profile name required, please pass via -profile flag")
-				os.Exit(0)
-			}
-			auth.NewUser(*credentialsFile, *profile, *username, *role)
-			return
-		}
-		if *deployFlag {
-			log.Printf("beginning deployment to %s using configuration specified in %s.json", *environ, *environ)
-			log.Printf("Using credentials found in : %s", *credentialsFile)
-			curdir, err := os.Getwd()
-			//err := deploy.CheckEnvironMatchConfig(*environ)
-			deploy.ErrorCheck(err)
-			//deploy.CreateDeployDirectory(*environ)
 
-			// Load the config to be passed to all deploy functions that require it
-			config := deploy.ParseDeploymentConfig(*environ)
-			if *all {
-				err := deploy.DeployAll(config, curdir, *environ)
-				if err != nil {
-					logger.Fatal(err)
-				}
-			} else {
-				if *vpc {
-					err := deploy.VPC(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *datastore {
-					err := deploy.Datastore(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *elasticsearch {
-					err := deploy.Elasticsearch(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *firehose {
-					err := deploy.Firehose(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *s3 {
-					err := deploy.S3(curdir, *environ)
-					if err != nil {
-						logger.Error(err)
-					}
-				}
-				if *secrets {
-					err := deploy.Secrets(curdir, *environ)
-					if err != nil {
-						logger.Error(err)
-					}
-				}
-				if *autoscaling {
-					err := deploy.Autoscaling(curdir, *environ)
-					if err != nil {
-						logger.Error(err)
-					}
-				}
-				if *packs {
-					err := deploy.DeployDefaultPacks(config, *environ)
-					if err != nil {
-						logger.Error(err)
-					}
-				}
-				if *configs {
-					err := deploy.DeployDefaultConfigs(config, *environ)
-					if err != nil {
-						logger.Error(err)
-					}
-				}
-				if *endpoints {
-					err := deploy.GenerateEndpointDeployScripts(config, *environ)
-					if err != nil {
-						logger.Error(err)
+			// Prompt for deployment confirmation
+			prompt := fmt.Sprintf("The following components will be deployed: %s\nDo you want to continue?", strings.Join(chosenOptions, ", "))
+			if helpers.ConfirmAction(prompt) {
+				for _, componentName := range chosenOptions {
+					if err = deploy.Component(config, componentName, envName); err != nil {
+						return err
 					}
 				}
 			}
-			return
 		}
-		if *destroy {
-			curdir, err := os.Getwd()
-			//err := deploy.CheckEnvironMatchConfig(*environ)
-			deploy.ErrorCheck(err)
-			if *all {
-				err := deploy.DestroyAutoscaling(curdir, *environ)
-				if err != nil {
-					logger.Fatal(err)
-				}
-				err = deploy.DestroySecrets(curdir, *environ)
-				if err != nil {
-					logger.Fatal(err)
-				}
-				err = deploy.DestroyS3(curdir, *environ)
-				if err != nil {
-					logger.Fatal(err)
-				}
-				err = deploy.DestroyFirehose(curdir, *environ)
-				if err != nil {
-					logger.Fatal(err)
-				}
-				err = deploy.DestroyElasticsearch(curdir, *environ)
-				if err != nil {
-					logger.Fatal(err)
-				}
-				err = deploy.DestroyDatastore(curdir, *environ)
-				if err != nil {
-					logger.Fatal(err)
-				}
-				err = deploy.DestroyVPC(curdir, *environ)
-				if err != nil {
-					logger.Fatal(err)
-				}
 
-			} else {
-				if *autoscaling {
-					err := deploy.DestroyAutoscaling(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *secrets {
-					err := deploy.DestroySecrets(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *s3 {
-					err := deploy.DestroyS3(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *firehose {
-					err := deploy.DestroyFirehose(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *elasticsearch {
-					err := deploy.DestroyElasticsearch(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *datastore {
-					err := deploy.DestroyDatastore(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
-				}
-				if *vpc {
-					err := deploy.DestroyVPC(curdir, *environ)
-					if err != nil {
-						logger.Fatal(err)
-					}
+	case runDestroy:
+
+		componentList := strings.Join(deploy.DeployOrder, ", ")
+
+		// Create a FlagSet for the destory command
+		destroyCommand := flag.NewFlagSet("deploy", flag.ExitOnError)
+		envFlag := destroyCommand.String("env", "", "Deployment environment name")
+		allFlag := destroyCommand.Bool("all", false, fmt.Sprintf("Destroy all components [%s]", componentList))
+
+		// Create a list of components to destroy that can be chosen from
+		var chosenDestroyOptions componentChoices
+		destroyCommand.Var(&chosenDestroyOptions, "components",
+			fmt.Sprintf("A comma-seperated (without spaces) list of components to destroy. Choices are: %s",
+				componentList))
+
+		destroyCommand.Parse(os.Args[2:])
+		envName := *envFlag
+		if envName == "" {
+			var err error
+			if envName, err = helpers.GetValueFromUser("Enter new environment name"); err != nil {
+				destroyCommand.Usage()
+				return err
+			}
+		}
+
+		chosenOptions, err := validateChoices(deploy.DeployOrder, chosenDestroyOptions)
+		if err != nil {
+			destroyCommand.Usage()
+			return err
+		}
+
+		if *allFlag {
+			if err = deploy.DestroyAllComponents(envName); err != nil {
+				return err
+			}
+		} else {
+
+			// Prompt for destroy confirmation
+			prompt := fmt.Sprintf("The following components will be destroyed: %s\nDo you want to continue?", strings.Join(chosenOptions, ", "))
+			if helpers.ConfirmAction(prompt) {
+				for _, componentName := range chosenOptions {
+					deploy.DestroyComponent(componentName, envName)
 				}
 			}
 		}
-	} else {
-		server()
+
+	case runServer:
+		return server.Serve()
+	default:
+		printHelp(nil)
 	}
 
+	return nil
+}
+
+func main() {
+	err := runSGT()
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	os.Exit(0)
 }


### PR DESCRIPTION
to: @securityclippy 
size: large

### Changes
* The sgt cli now accepts a 'subcommand' that dictates what actions should occur
  * Commands include: `create-user`, `deploy`, `destroy`, `new-deployment`, `server`, `wizard`
  * Updates to README.md for new subcommands
  * Input is sanitized/validated as best as possible
* The deploy package has been split up across multiple files
  * `deploy/apply.go` holds operations related to deploying aws and osquery components
  * `deploy/destroy.go` holds operations related to destroying aws components
  * `deploy/wizard.go` holds operations related to the wizard subcommand
* The deploy code has been simplified to be less redundant and all components are now deployable through one uniform interface.
  * The single `deployAWSComponent` function handles the tf init/apply.
  * Special cases for `s3` and `elasticsearch` components perform extra logic with this function.
* Various other bug fixes/optimizations
* Migrating 'serve' functionality to its own package
* Adding a stdout logging hook to be used when logging to a file that enables logging to both stdout and a file at the same time
  * This is especially useful for local debugging, to see output in console and have it in a file at the same time
* Adding helper functions (to the helpers package) for requesting user input/confirmation.

### Testing
* `go build` builds and tested various subcommands

This is a fairly large PR, so please feel free to reach out to me to discuss any/all of it!
