### PR TITLE
[vet] fixing areas where a mutex by was improperly being passed by value

### DIFF
--- a/handlers/deploy/deploy.go
+++ b/handlers/deploy/deploy.go
@@ -224,12 +224,12 @@ func osqueryDefaultPacks(config DeploymentConfig, environ string) error {
 				pq.Description = v.Description
 				pq.Interval = v.Interval
 				pq.Version = v.Version
-				dyndb.UpsertPackQuery(pq, dynDBInstance, mu)
+				dyndb.UpsertPackQuery(pq, dynDBInstance, &mu)
 			}
 			//logger.Info("queries done\n")
 			pack.Queries = helperPack.ListQueries()
 			pack.PackName = strings.Split(filename, ".")[0]
-			err = dyndb.UpsertPack(pack, dynDBInstance, mu)
+			err = dyndb.UpsertPack(pack, dynDBInstance, &mu)
 			if err != nil {
 				return err
 			}
@@ -315,14 +315,15 @@ func osqueryDefaultConfigs(config DeploymentConfig, environ string) error {
 		config.Packs = nil
 		namedConfig.Osquery_config = config
 		mu := sync.Mutex{}
-		ans := dyndb.UpsertNamedConfig(dynDB, &namedConfig, mu)
-
-		if ans {
-			logger.Infof("%s: success\n", namedConfig.Config_name)
-		} else {
+		err = dyndb.UpsertNamedConfig(dynDB, &namedConfig, &mu)
+		if err != nil {
 			logger.Infof("%s: failed\n", namedConfig.Config_name)
+			return err
 		}
+
+		logger.Infof("%s: success\n", namedConfig.Config_name)
 	}
+
 	return nil
 }
 

--- a/sgt.go
+++ b/sgt.go
@@ -179,7 +179,10 @@ func runSGT() error {
 			return errors.New("aws profile name required, please pass via -profile flag")
 		}
 
-		auth.NewUser(*credFileFlag, *profileFlag, *usernameFlag, *roleFlag)
+		err := auth.NewUser(*credFileFlag, *profileFlag, *usernameFlag, *roleFlag)
+		if err != nil {
+			return err
+		}
 
 	case runDeploy:
 


### PR DESCRIPTION
to @securityclippy 

### Changes
* Resolving a handful of locations where a mutex should have been passed by reference but was instead passed by value.
* Simplifying how the `ValidNode` function works and return errors with more context.
* Updating the call to `auth.NewUser` to check for errors and cleaning up the `NewUser` function.
* Immediately `defer`ing the mutex unlock when lock is called as to not block other operations if the function returns early.

### Testing
* Building with `go build` and `govet` errors related to mutex are now resolved.