### PR TITLE
[api] updating request handlers to handle/report errors more granularly with context

### DIFF
--- a/handlers/api/api.go
+++ b/handlers/api/api.go
@@ -146,9 +146,9 @@ func ConfigureNode(respWriter http.ResponseWriter, request *http.Request) {
 	handleRequest := func() (interface{}, error) {
 
 		vars := mux.Vars(request)
-		nodeKey, ok := vars["nodeKey"]
+		nodeKey, ok := vars["node_key"]
 		if !ok || nodeKey == "" {
-			return nil, errors.New("request does not contain nodeKey")
+			return nil, errors.New("request does not contain node_key")
 		}
 
 		dynDBInstance := dyndb.DbInstance()
@@ -156,6 +156,8 @@ func ConfigureNode(respWriter http.ResponseWriter, request *http.Request) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to find node by key [%s]: %s", nodeKey, err)
 		}
+
+		logger.Infof("existing client: %+v", existingClient)
 
 		switch request.Method {
 		case http.MethodGet:
@@ -165,7 +167,7 @@ func ConfigureNode(respWriter http.ResponseWriter, request *http.Request) {
 		case http.MethodPost:
 
 			if existingClient.NodeKey == "" {
-				return nil, errors.New("existing client nodeKey is empty")
+				return nil, errors.New("existing client node_key is empty")
 			}
 
 			body, err := ioutil.ReadAll(request.Body)
@@ -181,7 +183,7 @@ func ConfigureNode(respWriter http.ResponseWriter, request *http.Request) {
 				return nil, fmt.Errorf("failed to unmarshal request body [%s]: %s", string(body), err)
 			}
 
-			logger.Warn("%v", client)
+			logger.Infof("new client: %+v", client)
 
 			//map missing keys to client
 			client.NodeKey = nodeKey
@@ -230,9 +232,9 @@ func ApproveNode(respWriter http.ResponseWriter, request *http.Request) {
 	handleRequest := func() error {
 
 		vars := mux.Vars(request)
-		nodeKey, ok := vars["nodeKey"]
+		nodeKey, ok := vars["node_key"]
 		if !ok || nodeKey == "" {
-			return errors.New("request does not contain nodeKey")
+			return errors.New("request does not contain node_key")
 		}
 
 		logger.Warn("posting approval")
@@ -405,9 +407,8 @@ func ConfigurePack(respWriter http.ResponseWriter, request *http.Request) {
 			return fmt.Errorf("failed to unmarshal request body [%s]: %s", string(body), err)
 		}
 
-		mu := sync.Mutex{}
 		dynDBInstance := dyndb.DbInstance()
-		err = dyndb.UpsertPack(querypack, dynDBInstance, &mu)
+		err = dyndb.UpsertPack(querypack, dynDBInstance)
 		if err != nil {
 			return fmt.Errorf("dynamo pack upsert failed: %s", err)
 		}

--- a/handlers/api/api.go
+++ b/handlers/api/api.go
@@ -2,14 +2,15 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"sync"
 
 	"github.com/gorilla/mux"
 	"github.com/oktasecuritylabs/sgt/dyndb"
+	"github.com/oktasecuritylabs/sgt/handlers/response"
 	"github.com/oktasecuritylabs/sgt/logger"
 	"github.com/oktasecuritylabs/sgt/osquery_types"
 	log "github.com/sirupsen/logrus"
@@ -23,388 +24,454 @@ func init() {
 }
 
 //GetNamedConfigs returns all named configs in a json list
-func GetNamedConfigs(w http.ResponseWriter, r *http.Request) {
-	dynDBInstance := dyndb.DbInstance()
-	ans, err := dyndb.GetNamedConfigs(dynDBInstance)
+func GetNamedConfigs(respWriter http.ResponseWriter, r *http.Request) {
+
+	handleRequest := func() (interface{}, error) {
+
+		dynDBInstance := dyndb.DbInstance()
+		ans, err := dyndb.GetNamedConfigs(dynDBInstance)
+		if err != nil {
+			return nil, fmt.Errorf("could not get named configs: %s", err)
+		}
+
+		return ans, nil
+	}
+
+	result, err := handleRequest()
 	if err != nil {
 		logger.Error(err)
-		w.Write([]byte(`{"error": true}`))
-		return
+		errString := fmt.Sprintf("[GetNamedConfigs] failed to get named configs: %s", err)
+		response.WriteError(respWriter, errString)
+	} else {
+		response.WriteCustomJSON(respWriter, result)
 	}
-	js, err := json.Marshal(ans)
+}
+
+// ConfigurationRequest accepts a json post body of a NamedConfig
+func ConfigurationRequest(respWriter http.ResponseWriter, request *http.Request) {
+
+	handleRequest := func() (interface{}, error) {
+
+		vars := mux.Vars(request)
+		configName, ok := vars["config_name"]
+		if !ok || configName == "" {
+			return nil, errors.New("no config name specified")
+		}
+
+		// get the named config
+		dynDBInstance := dyndb.DbInstance()
+		existingNamedConfig, err := dyndb.GetNamedConfig(dynDBInstance, configName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get config with name [%s]: %s", configName, err)
+		}
+
+		switch request.Method {
+		case http.MethodGet:
+
+			return existingNamedConfig, nil
+
+		case http.MethodPost:
+
+			//now merge what's already in teh database with our defaults
+			existingNamedConfig.OsqueryConfig.Options = osquery_types.NewOsqueryOptions()
+
+			// finally...
+			body, err := ioutil.ReadAll(request.Body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read request body: %s", err)
+			}
+
+			//overlay default + existing with options provided by user
+			err = json.Unmarshal(body, &existingNamedConfig)
+			if err != nil {
+				return nil, fmt.Errorf("merging of named configs failed: %s", err)
+			}
+
+			if configName != existingNamedConfig.ConfigName {
+				return nil, errors.New("named config endpoint does not match posted data config_name")
+			}
+
+			mu := sync.Mutex{}
+			err = dyndb.UpsertNamedConfig(dynDBInstance, &existingNamedConfig, &mu)
+			if err != nil {
+				return nil, fmt.Errorf("dynamo named config upsert failed: %s", err)
+			}
+
+			return existingNamedConfig, nil
+		}
+
+		return nil, fmt.Errorf("method not supported: %s", request.Method)
+	}
+
+	result, err := handleRequest()
 	if err != nil {
 		logger.Error(err)
-		w.Write([]byte(`{"error": true}`))
+		errString := fmt.Sprintf("[ConfigurationRequest] failed to handle named config in %s request: %s", request.Method, err)
+		response.WriteError(respWriter, errString)
+	} else {
+		response.WriteCustomJSON(respWriter, result)
+	}
+}
+
+// GetNodes returns json reponse of a list of nodes
+func GetNodes(respWriter http.ResponseWriter, request *http.Request) {
+	// Only handle GET requests
+	if request.Method != http.MethodGet {
 		return
 	}
-	w.Write(js)
-}
 
-//ConfigurationRequest accepts a json post body of a NamedConfig
-func ConfigurationRequest(respwritter http.ResponseWriter, request *http.Request) {
-	mu := sync.Mutex{}
-	dynDBInstance := dyndb.DbInstance()
-	vars := mux.Vars(request)
-	if request.Method == "GET" {
-		if vars["config_name"] == "" {
-			ans, err := dyndb.GetNamedConfig(dynDBInstance, vars["config_name"])
-			if err != nil {
-				logger.Error(err)
-			}
-			js, err := json.Marshal(ans)
-			if err != nil {
-				logger.Error(err)
-			}
-			respwritter.Write(js)
-			//return list of configs
-		} else {
-			//return named config
-			ans, err := dyndb.GetNamedConfig(dynDBInstance, vars["config_name"])
-			if err != nil {
-				logger.Error(err)
-			}
-			js, err := json.Marshal(ans)
-			if err != nil {
-				logger.Error(err)
-			}
-			respwritter.Write(js)
+	handleRequest := func() (interface{}, error) {
+
+		results, err := dyndb.SearchByHostIdentifier("", dyndb.DbInstance())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get all nodes: %s", err)
 		}
+
+		return results, nil
 	}
-	if request.Method == "POST" {
-		if vars["config_name"] == "" {
-			respwritter.Write([]byte(`{"result":"failure"}`))
-			return
-		}
-		//Create base osquery named config with default options
-		namedConfig := osquery_types.OsqueryNamedConfig{}
-		namedConfig.OsqueryConfig.Options = osquery_types.NewOsqueryOptions()
-		existingNamedConfig, err := dyndb.GetNamedConfig(dynDBInstance, vars["config_name"])
-		//now merge what's already in teh database with our defaults
-		js, err := json.Marshal(existingNamedConfig)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
-		err = json.Unmarshal(js, &namedConfig)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
-		// finally...
-		body, err := ioutil.ReadAll(request.Body)
-		if err != nil {
-			panic(err)
-		}
-		//overlay default + existing with options provided by user
-		err = json.Unmarshal(body, &namedConfig)
-		if err != nil {
-			panic(fmt.Sprintln(err, os.Stdout))
-		}
-		if vars["config_name"] != namedConfig.ConfigName {
-			respwritter.Write([]byte(`{"result":"failure", "reason": "named config endpoint does not match posted data config_name"}`))
-			return
-		}
 
-		err = dyndb.UpsertNamedConfig(dynDBInstance, &namedConfig, &mu)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
-	}
-	return
-}
-
-//GetNodes returns json reponse of a list of nodes
-func GetNodes(respwritter http.ResponseWriter, request *http.Request) {
-	dynDBInstance := dyndb.DbInstance()
-	//nodes := osquery_types.OsqueryClient{}
-	if request.Method == "GET" {
-		results, err := dyndb.SearchByHostIdentifier("", dynDBInstance)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
-		js, err := json.Marshal(results)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
-		respwritter.Write(js)
-		return
-	}
-}
-
-//ConfigureNode accepts json node configuration
-func ConfigureNode(respwritter http.ResponseWriter, request *http.Request) {
-	dynDBInstance := dyndb.DbInstance()
-	mu := sync.Mutex{}
-	vars := mux.Vars(request)
-	nodeKey := vars["node_key"]
-	client := osquery_types.OsqueryClient{}
-	body, err := ioutil.ReadAll(request.Body)
+	result, err := handleRequest()
 	if err != nil {
-		panic(err)
-	}
-	//set posted osquery client = client
-	err = json.Unmarshal(body, &client)
-	logger.Infof("%+v", client)
-	if request.Method == "GET" {
-		if vars["node_key"] != "" {
-			result, err := dyndb.SearchByNodeKey(client.NodeKey, dynDBInstance)
-			if err != nil {
-				logger.Error(err)
-			}
-			if result.HostIdentifier != "" {
-				js, err := json.Marshal(result)
-				if err != nil {
-					logger.Error(err)
-				}
-				respwritter.Write(js)
-				return
-			}
-		}
-	}
-	if request.Method == "POST" {
-		if vars["node_key"] != "" {
-			//verify that node exists
-			//get existing client config
-			//rewrite this crappy shit
-			existingClient, err := dyndb.SearchByNodeKey(nodeKey, dynDBInstance)
-			if err != nil {
-				logger.Error(err)
-			}
-			logger.Infof("%+v", existingClient)
-			if err != nil {
-				logger.Error(err)
-				respwritter.Write([]byte(`{"error": "node invalid"}`))
-				return
-			}
-			if len(existingClient.NodeKey) > 0 {
-				//map missing keys to client
-				client.NodeKey = nodeKey
-				if len(client.ConfigName) <= 0 {
-					client.ConfigName = existingClient.ConfigName
-				}
-				client.HostIdentifier = existingClient.HostIdentifier
-				if client.NodeInvalid != true {
-					if client.NodeInvalid != false {
-						client.NodeInvalid = existingClient.NodeInvalid
-					}
-				}
-				client.HostDetails = existingClient.HostDetails
-				if client.PendingRegistrationApproval != false {
-					if client.PendingRegistrationApproval != true {
-						client.PendingRegistrationApproval = existingClient.PendingRegistrationApproval
-					}
-				}
-				if len(client.Tags) < 1 {
-					client.Tags = existingClient.Tags
-				}
-				logger.Warn("%v", client)
-				err := dyndb.UpsertClient(client, dynDBInstance, &mu)
-				if err != nil {
-					logger.Error(err)
-					respwritter.Write([]byte(`{"error": "update failed"}`))
-					return
-				}
-				js, err := json.Marshal(client)
-				if err != nil {
-					logger.Error(err)
-					return
-				}
-				respwritter.Write(js)
-				return
-			}
-		}
-		//Results := dyndb.SearchByHostIdentifier("", dynDBInstance)
-	}
-	if request.Method == "GET" {
-		//nodeKey := vars["nodeKey"]
-		client, err := dyndb.SearchByNodeKey(nodeKey, dynDBInstance)
-		if err != nil {
-			logger.Error(err)
-		}
-		js, err := json.Marshal(client)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
-		respwritter.Write(js)
-		return
+		logger.Error(err)
+		errString := fmt.Sprintf("[GetNodes] %s", err)
+		response.WriteError(respWriter, errString)
+	} else {
+		response.WriteCustomJSON(respWriter, result)
 	}
 }
 
-//ApproveNode helper function as a shortcut to approving node.  Takes no body input
-func ApproveNode(respwritter http.ResponseWriter, request *http.Request) {
-	dynDBInstance := dyndb.DbInstance()
-	mu := sync.Mutex{}
-	vars := mux.Vars(request)
-	if request.Method == "POST" {
+// ConfigureNode accepts json node configuration
+func ConfigureNode(respWriter http.ResponseWriter, request *http.Request) {
+
+	handleRequest := func() (interface{}, error) {
+
+		vars := mux.Vars(request)
+		nodeKey, ok := vars["nodeKey"]
+		if !ok || nodeKey == "" {
+			return nil, errors.New("request does not contain nodeKey")
+		}
+
+		dynDBInstance := dyndb.DbInstance()
+		existingClient, err := dyndb.SearchByNodeKey(nodeKey, dynDBInstance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find node by key [%s]: %s", nodeKey, err)
+		}
+
+		switch request.Method {
+		case http.MethodGet:
+
+			return existingClient, nil
+
+		case http.MethodPost:
+
+			if existingClient.NodeKey == "" {
+				return nil, errors.New("existing client nodeKey is empty")
+			}
+
+			body, err := ioutil.ReadAll(request.Body)
+			defer request.Body.Close()
+			if err != nil {
+				return nil, fmt.Errorf("failed to read request body: %s", err)
+			}
+
+			//set posted osquery client = client
+			client := osquery_types.OsqueryClient{}
+			err = json.Unmarshal(body, &client)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal request body [%s]: %s", string(body), err)
+			}
+
+			logger.Warn("%v", client)
+
+			//map missing keys to client
+			client.NodeKey = nodeKey
+			if client.ConfigName == "" {
+				client.ConfigName = existingClient.ConfigName
+			}
+			client.HostIdentifier = existingClient.HostIdentifier
+			client.NodeInvalid = client.NodeInvalid || existingClient.NodeInvalid
+			client.PendingRegistrationApproval = client.PendingRegistrationApproval && existingClient.PendingRegistrationApproval
+			client.HostDetails = existingClient.HostDetails
+
+			if len(client.Tags) == 0 {
+				client.Tags = existingClient.Tags
+			}
+
+			mu := sync.Mutex{}
+			err = dyndb.UpsertClient(client, dynDBInstance, &mu)
+			if err != nil {
+				return nil, fmt.Errorf("client update in dynamo failed: %s", err)
+			}
+
+			return client, nil
+		}
+
+		return nil, fmt.Errorf("method not supported: %s", request.Method)
+	}
+
+	result, err := handleRequest()
+	if err != nil {
+		logger.Error(err)
+		errString := fmt.Sprintf("[ConfigureNode] failed to configure node in %s request: %s", request.Method, err)
+		response.WriteError(respWriter, errString)
+	} else {
+		response.WriteCustomJSON(respWriter, result)
+	}
+}
+
+// ApproveNode helper function as a shortcut to approving node.  Takes no body input
+func ApproveNode(respWriter http.ResponseWriter, request *http.Request) {
+
+	// Only handle POST requests
+	if request.Method != http.MethodPost {
+		return
+	}
+
+	handleRequest := func() error {
+
+		vars := mux.Vars(request)
+		nodeKey, ok := vars["nodeKey"]
+		if !ok || nodeKey == "" {
+			return errors.New("request does not contain nodeKey")
+		}
+
 		logger.Warn("posting approval")
-		err := dyndb.ApprovePendingNode(vars["node_key"], dynDBInstance, &mu)
-		logger.Infof("[ApproveNode] vars: %+v", vars)
+
+		mu := sync.Mutex{}
+		dynDBInstance := dyndb.DbInstance()
+		err := dyndb.ApprovePendingNode(nodeKey, dynDBInstance, &mu)
 		if err != nil {
-			logger.Error(err)
-			respwritter.Write([]byte(`{"result": "error"}`))
-			return
+			return fmt.Errorf("approval of pending node failed: %s", err)
 		}
-		respwritter.Write([]byte(`{"result": "success"}`))
-		return
+
+		return nil
+	}
+
+	err := handleRequest()
+	if err != nil {
+		logger.Error(err)
+		errString := fmt.Sprintf("[ApproveNode] failed to approve node: %s", err)
+		response.WriteError(respWriter, errString)
+	} else {
+		response.WriteSuccess(respWriter, "")
 	}
 }
 
-//GetPackQueries returns json response of a list of packqueries
-func GetPackQueries(respwritter http.ResponseWriter, request *http.Request) {
-	type packQueryList struct {
-		packqueries []osquery_types.PackQuery `json:"packqueries"`
+// GetPackQueries returns json response of a list of packqueries
+func GetPackQueries(respWriter http.ResponseWriter, request *http.Request) {
+
+	// Only handle GET requests
+	if request.Method != http.MethodGet {
+		return
 	}
-	//pql := packQueryList{}
-	dynDBInstance := dyndb.DbInstance()
-	if request.Method == "GET" {
+
+	handleRequest := func() (interface{}, error) {
+
+		dynDBInstance := dyndb.DbInstance()
 		results, err := dyndb.APIGetPackQueries(dynDBInstance)
 		if err != nil {
-			logger.Error(err)
+			return nil, fmt.Errorf("failed to get query packs: %s", err)
 		}
-		js, err := json.Marshal(results)
-		if err != nil {
-			logger.Error(err)
-		}
-		respwritter.Write(js)
+
+		return results, nil
+	}
+
+	result, err := handleRequest()
+	if err != nil {
+		logger.Error(err)
+		errString := fmt.Sprintf("[GetPackQueries] %s", err)
+		response.WriteError(respWriter, errString)
+	} else {
+		response.WriteCustomJSON(respWriter, result)
 	}
 }
 
-//SearchPackQueries searches all packqueries by substring
-func SearchPackQueries(respwritter http.ResponseWriter, request *http.Request) {
-	vars := mux.Vars(request)
-	type packQueryList struct {
-		packqueries []osquery_types.PackQuery `json:"packqueries"`
-	}
-	//pql := packQueryList{}
-	dynDBInstance := dyndb.DbInstance()
-	if request.Method == "GET" {
-		results, err := dyndb.APISearchPackQueries(vars["search_string"], dynDBInstance)
-		if err != nil {
-			logger.Error(err)
-		}
-		js, err := json.Marshal(results)
-		if err != nil {
-			logger.Error(err)
-		}
-		respwritter.Write(js)
-	}
-}
+// SearchPackQueries searches all packqueries by substring
+func SearchPackQueries(respWriter http.ResponseWriter, request *http.Request) {
 
-//GetQueryPacks returns all querypacks
-func GetQueryPacks(respwritter http.ResponseWriter, request *http.Request) {
-	type packQueryList struct {
-		QueryPacks []osquery_types.QueryPack `json:"query_packs"`
-	}
-	dynDBInstance := dyndb.DbInstance()
-	if request.Method == "GET" {
-		results, err := dyndb.SearchQueryPacks("", dynDBInstance)
-		if err != nil {
-			logger.Error(err)
-		}
-		js, err := json.Marshal(results)
-		if err != nil {
-			logger.Error(err)
-		}
-		respwritter.Write(js)
-	}
-}
-
-//SearchQueryPacks search for substring in query pack name
-func SearchQueryPacks(respwritter http.ResponseWriter, request *http.Request) {
-	vars := mux.Vars(request)
-	type packQueryList struct {
-		QueryPacks []osquery_types.QueryPack `json:"query_packs"`
-	}
-	dynDBInstance := dyndb.DbInstance()
-	if request.Method == "GET" {
-		results, err := dyndb.SearchQueryPacks(vars["search_string"], dynDBInstance)
-		if err != nil {
-			logger.Error(err)
-		}
-		js, err := json.Marshal(results)
-		if err != nil {
-			logger.Error(err)
-		}
-		respwritter.Write(js)
-	}
-}
-
-//ConfigurePack configures named pack
-func ConfigurePack(respwritter http.ResponseWriter, request *http.Request) {
-	vars := mux.Vars(request)
-	if len(vars["pack_name"]) < 1 {
-		respwritter.Write([]byte(`No pack specified`))
-		logger.Error("No pack specified")
+	// Only handle GET requests
+	if request.Method != http.MethodGet {
 		return
 	}
-	//pname := vars["pack_name"]
-	dynDBInstance := dyndb.DbInstance()
-	if request.Method == "POST" {
+
+	handleRequest := func() (interface{}, error) {
+
+		vars := mux.Vars(request)
+		dynDBInstance := dyndb.DbInstance()
+		searchString := vars["search_string"]
+		results, err := dyndb.APISearchPackQueries(searchString, dynDBInstance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to search pack queries for string '%s': %s", searchString, err)
+		}
+
+		return results, nil
+	}
+
+	result, err := handleRequest()
+	if err != nil {
+		logger.Error(err)
+		errString := fmt.Sprintf("[SearchPackQueries] %s", err)
+		response.WriteError(respWriter, errString)
+	} else {
+		response.WriteCustomJSON(respWriter, result)
+	}
+}
+
+// GetQueryPacks returns all querypacks
+func GetQueryPacks(respWriter http.ResponseWriter, request *http.Request) {
+
+	// Only handle GET requests
+	if request.Method != http.MethodGet {
+		return
+	}
+
+	handleRequest := func() (interface{}, error) {
+
+		dynDBInstance := dyndb.DbInstance()
+		results, err := dyndb.SearchQueryPacks("", dynDBInstance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get all query packs: %s", err)
+		}
+
+		return results, nil
+	}
+
+	result, err := handleRequest()
+	if err != nil {
+		logger.Error(err)
+		errString := fmt.Sprintf("[GetQueryPacks] %s", err)
+		response.WriteError(respWriter, errString)
+	} else {
+		response.WriteCustomJSON(respWriter, result)
+	}
+}
+
+// SearchQueryPacks search for substring in query pack name
+func SearchQueryPacks(respWriter http.ResponseWriter, request *http.Request) {
+
+	// Only handle GET requests
+	if request.Method != http.MethodGet {
+		return
+	}
+
+	handleRequest := func() (interface{}, error) {
+
+		vars := mux.Vars(request)
+		dynDBInstance := dyndb.DbInstance()
+		searchString := vars["search_string"]
+		results, err := dyndb.SearchQueryPacks(searchString, dynDBInstance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to search query packs for string '%s': %s", searchString, err)
+		}
+
+		return results, nil
+	}
+
+	result, err := handleRequest()
+	if err != nil {
+		logger.Error(err)
+		errString := fmt.Sprintf("[SearchQueryPacks] %s", err)
+		response.WriteError(respWriter, errString)
+	} else {
+		response.WriteCustomJSON(respWriter, result)
+	}
+}
+
+// ConfigurePack configures named pack
+func ConfigurePack(respWriter http.ResponseWriter, request *http.Request) {
+
+	// Only handle POST requests
+	if request.Method != http.MethodPost {
+		return
+	}
+
+	handleRequest := func() error {
+
+		vars := mux.Vars(request)
+		packName, ok := vars["pack_name"]
+		if !ok || packName == "" {
+			return errors.New("no pack specified")
+		}
+
 		body, err := ioutil.ReadAll(request.Body)
 		defer request.Body.Close()
 		if err != nil {
-			logger.Error(err)
+			return fmt.Errorf("failed to read request body: %s", err)
 		}
+
 		querypack := osquery_types.QueryPack{}
 		err = json.Unmarshal(body, &querypack)
 		if err != nil {
-			logger.Error(err)
-			return
+			return fmt.Errorf("failed to unmarshal request body [%s]: %s", string(body), err)
 		}
-		err = dyndb.UpsertPack(querypack, dynDBInstance)
+
+		mu := sync.Mutex{}
+		dynDBInstance := dyndb.DbInstance()
+		err = dyndb.UpsertPack(querypack, dynDBInstance, &mu)
 		if err != nil {
-			logger.Error(err)
-			return
+			return fmt.Errorf("dynamo pack upsert failed: %s", err)
 		}
+
+		return nil
 	}
 
+	err := handleRequest()
+	if err != nil {
+		logger.Error(err)
+		errString := fmt.Sprintf("[ConfigurePack] %s", err)
+		response.WriteError(respWriter, errString)
+	}
 }
 
-//ConfigurePackQuery accepts post body with packquery config
-func ConfigurePackQuery(respwritter http.ResponseWriter, request *http.Request) {
-	mu := sync.Mutex{}
-	vars := mux.Vars(request)
-	if len(vars["query_name"]) < 1 {
-		respwritter.Write([]byte(`No pack specified`))
-		logger.Error("No pack specified")
-		return
-	}
-	qname := vars["query_name"]
-	dynDBInstance := dyndb.DbInstance()
-	if request.Method == "GET" {
-		packQuery, err := dyndb.GetPackQuery(qname, dynDBInstance)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
-		js, err := json.Marshal(packQuery)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
-		respwritter.Write(js)
+// ConfigurePackQuery accepts post body with packquery config
+func ConfigurePackQuery(respWriter http.ResponseWriter, request *http.Request) {
 
+	handleRequest := func() error {
+
+		dynDBInstance := dyndb.DbInstance()
+
+		switch request.Method {
+		case http.MethodGet:
+
+			vars := mux.Vars(request)
+			qName, ok := vars["query_name"]
+			if !ok || qName == "" {
+				return errors.New("no pack specified")
+			}
+
+			packQuery, err := dyndb.GetPackQuery(qName, dynDBInstance)
+			if err != nil {
+				return fmt.Errorf("failed to get pack query: %s", err)
+			}
+
+			response.WriteCustomJSON(respWriter, packQuery)
+
+		case http.MethodPost:
+			body, err := ioutil.ReadAll(request.Body)
+			defer request.Body.Close()
+			if err != nil {
+				return fmt.Errorf("failed to read request body: %s", err)
+			}
+
+			var postData osquery_types.PackQuery
+			err = json.Unmarshal(body, &postData)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal request body [%s]: %s", string(body), err)
+			}
+
+			mu := sync.Mutex{}
+			err = dyndb.UpsertPackQuery(postData, dynDBInstance, &mu)
+			if err != nil {
+				return fmt.Errorf("dynamo pack query upsert failed: %s", err)
+			}
+		}
+		return nil
 	}
-	if request.Method == "POST" {
-		body, err := ioutil.ReadAll(request.Body)
-		defer request.Body.Close()
-		if err != nil {
-			logger.Error(err)
-		}
-		var postData osquery_types.PackQuery
-		err = json.Unmarshal(body, &postData)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
-		err = dyndb.UpsertPackQuery(postData, dynDBInstance, &mu)
-		if err != nil {
-			logger.Error(err)
-			return
-		}
+
+	err := handleRequest()
+	if err != nil {
+		logger.Error(err)
+		errString := fmt.Sprintf("[ConfigurePackQuery] %s request failed: %s", request.Method, err)
+		response.WriteError(respWriter, errString)
 	}
 }

--- a/handlers/deploy/apply.go
+++ b/handlers/deploy/apply.go
@@ -229,7 +229,7 @@ func createElasticSearchMappings() error {
 	uri := fmt.Sprintf("https://%s/%s", esEndpoint, path)
 	logger.Info(uri)
 
-	req, _ := http.NewRequest("PUT", uri, bytes.NewBuffer(rawJSON))
+	req, _ := http.NewRequest(http.MethodPut, uri, bytes.NewBuffer(rawJSON))
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	response, _ := client.Do(req)

--- a/handlers/deploy/deploy.go
+++ b/handlers/deploy/deploy.go
@@ -23,17 +23,17 @@ import (
 )
 
 const (
-	vpc           = "vpc"
-	datastore     = "datastore"
-	elasticsearch = "elasticsearch"
-	firehose      = "firehose"
+	vpc                   = "vpc"
+	datastore             = "datastore"
+	elasticsearch         = "elasticsearch"
+	firehose              = "firehose"
 	elasticsearchFirehose = "elasticsearch_firehose"
-	s3            = "s3"
-	secrets       = "secrets"
-	autoscaling   = "autoscaling"
-	packs         = "packs"
-	configs       = "configs"
-	scripts       = "scripts"
+	s3                    = "s3"
+	secrets               = "secrets"
+	autoscaling           = "autoscaling"
+	packs                 = "packs"
+	configs               = "configs"
+	scripts               = "scripts"
 )
 
 var (
@@ -87,7 +87,7 @@ type DeploymentConfig struct {
 	SslPrivateKey               string `json:"ssl_private_key"`
 	SgtNodeSecret               string `json:"sgt_node_secret"`
 	SgtAppSecret                string `json:"sgt_app_secret"`
-	CreateElasticsearch			int	`json:"create_elasticsearch"`
+	CreateElasticsearch         int    `json:"create_elasticsearch"`
 }
 
 // copyFile copies file from src to dst
@@ -256,7 +256,7 @@ func osqueryDefaultConfigs(config DeploymentConfig, environ string) error {
 	var files []string
 
 	//if environ specific dir exists in packs, deploy those.  Otherwise use defaults
-	envSpecificConfigs := false
+	var envSpecificConfigs bool
 	if _, err := os.Stat(filepath.Join("osquery_configs", environ)); os.IsNotExist(err) {
 		logger.Infof("No environment specific configs found for: %s\n", environ)
 		logger.Info("using default configs")
@@ -273,7 +273,6 @@ func osqueryDefaultConfigs(config DeploymentConfig, environ string) error {
 		files, err = filepath.Glob(path)
 		if err != nil {
 			return err
-			logger.Fatal(err)
 		}
 	}
 	//spin.Start()
@@ -288,7 +287,7 @@ func osqueryDefaultConfigs(config DeploymentConfig, environ string) error {
 		logger.Infof("Updating %s pack", filename)
 		if strings.HasSuffix(filename, "json") {
 		}
-		fp := ""
+		var fp string
 		if envSpecificConfigs {
 			fp = filepath.Join("osquery_configs", environ, filename)
 		} else {

--- a/handlers/node/node.go
+++ b/handlers/node/node.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/oktasecuritylabs/sgt/dyndb"
 	"github.com/oktasecuritylabs/sgt/handlers/auth"
+	"github.com/oktasecuritylabs/sgt/handlers/response"
 	"github.com/oktasecuritylabs/sgt/logger"
 	"github.com/oktasecuritylabs/sgt/osquery_types"
 	log "github.com/sirupsen/logrus"
@@ -33,219 +35,240 @@ func RandomString(strlen int) string {
 	return strings.Join(result, "")
 }
 
+// NodeEnrollRequest enrolls a node given the host identifier
 func NodeEnrollRequest(respWriter http.ResponseWriter, request *http.Request) {
-	dump, _ := httputil.DumpRequest(request, true)
-	logger.Debug(string(dump))
-	dynSvc := dyndb.DbInstance()
 
-	mu := sync.Mutex{}
+	handleRequest := func() error {
 
-	respWriter.Header().Set("Content-Type", "application/json")
-	//test if enrol secret is correct
-	dump, err := httputil.DumpRequest(request, true)
-	logger.Info(string(dump))
-	if err != nil {
-		logger.Error(string(dump))
-		logger.Error(err)
-		return
-	}
-	sekret, err := auth.GetNodeSecret()
-	if err != nil {
-		logger.Error(err)
-	}
-	if len(sekret) <= 3 {
-		logger.Warn("Node secret too short, exiting.")
-		respWriter.Write([]byte(fmt.Sprintf("actual secret: %s", sekret)))
-		return
-	}
-	//check if enroll secret is accurate
-	//if enroll secret is correct check if hostname registered
-	//if hostname registered, send config
-	//if not, send back to pending registration
-	type EnrollRequest struct {
-		EnrollSecret   string                       `json:"enroll_secret"`
-		NodeKey        string                       `json:"node_key"`
-		HostIdentifier string                       `json:"host_identifier"`
-		PlatformType   string                       `json:"platform_type"`
-		HostDetails    map[string]map[string]string `json:"host_details"`
-	}
-	type EnrollRequestResponse struct {
-		NodeKey     string `json:"node_key"`
-		NodeInvalid bool   `json:"node_invalid"`
-	}
-	//fmt.Println(request.Body)
-	nodeEnrollRequestLogger := logger.WithFields(log.Fields{
-		"node_ip_address": request.RemoteAddr,
-		"user_agent":      request.UserAgent(),
-	})
-	body, err := ioutil.ReadAll(request.Body)
-	logger.Info(string(body))
-	defer request.Body.Close()
-	if err != nil {
-		nodeEnrollRequestLogger.Error(err)
-	}
-	data := EnrollRequest{}
-	err = json.Unmarshal(body, &data)
-	if err != nil {
-		nodeEnrollRequestLogger.Error(err)
-	}
-	if string(data.EnrollSecret) == sekret {
+		//test if enrol secret is correct
+		dump, err := httputil.DumpRequest(request, true)
+		logger.Info(string(dump))
+		if err != nil {
+			return fmt.Errorf("could not dump request: %s", err)
+		}
+
+		sekret, err := auth.GetNodeSecret()
+		if err != nil {
+			return fmt.Errorf("could not get node secret: %s", err)
+		}
+
+		if len(sekret) <= 3 {
+			return fmt.Errorf("node secret too short: %s", sekret)
+		}
+
+		//check if enroll secret is accurate
+		//if enroll secret is correct check if hostname registered
+		//if hostname registered, send config
+		//if not, send back to pending registration
+		type EnrollRequest struct {
+			NodeConfigurePost
+			PlatformType string                       `json:"platform_type"`
+			HostDetails  map[string]map[string]string `json:"host_details"`
+		}
+		type EnrollRequestResponse struct {
+			NodeKey     string `json:"node_key"`
+			NodeInvalid bool   `json:"node_invalid"`
+		}
+
+		nodeEnrollRequestLogger := logger.WithFields(log.Fields{
+			"node_ip_address": request.RemoteAddr,
+			"user_agent":      request.UserAgent(),
+		})
+
+		body, err := ioutil.ReadAll(request.Body)
+		logger.Info(string(body))
+		defer request.Body.Close()
+		if err != nil {
+			nodeEnrollRequestLogger.Error(err)
+			return fmt.Errorf("failed to read request body: %s", err)
+		}
+
+		data := EnrollRequest{}
+		err = json.Unmarshal(body, &data)
+		if err != nil {
+			nodeEnrollRequestLogger.Error(err)
+			return fmt.Errorf("unmarshal failed: %s", err)
+		}
+
+		if string(data.EnrollSecret) != sekret {
+			return errors.New("node secret does not match enroll secret")
+		}
+
 		nodeEnrollRequestLogger.WithFields(log.Fields{
 			"hostname": data.HostIdentifier,
 		}).Info("Correct sekret received")
-		//Need more error handling here.  what if node key is valid but hostname is duplicate?
-		if data.NodeKey == "" {
-			ans, err := dyndb.SearchByHostIdentifier(data.HostIdentifier, dynSvc)
-			if err != nil {
-				logger.Error(err)
-				return
-			}
-			if len(ans) > 0 {
-				nodeEnrollRequestLogger.WithFields(log.Fields{
-					"hostname": data.HostIdentifier,
-				}).Info("host already exists, setting host to existing node_key")
-				enrollRequestResponse := EnrollRequestResponse{ans[0].NodeKey, false}
-				osc := ans[0]
-				osc.Timestamp()
-				err := dyndb.UpsertClient(osc, dynSvc, &mu)
-				if err != nil {
-					nodeEnrollRequestLogger.Error(err)
-					return
-				}
-				// might be good to check for dupe hostnames here before ACTUALLY issuing new key
-				js, _ := json.Marshal(enrollRequestResponse)
-				respWriter.Write(js)
-			} else {
-				// this will trigger a new enrollment request.  Upon creation of this request, it might be
-				//a good idea to generate a post event to an endpoint to notify of a pending enrollment
-				//approval
-				// this could also be taken care of by a separate worker that sweeps for pending enrollments.
-				// work may be better, as this task can be assigned to a lambda and gives more flexibility to the
-				//post endpoint
-				nodeKey := RandomString(20)
-				nodeEnrollRequestLogger.WithFields(log.Fields{
-					"hostname": data.HostIdentifier,
-				}).Info("generating new  node_key")
-				enrollRequestResponse := EnrollRequestResponse{nodeKey, false}
-				// Handle enrollment defaults here.  Default configs for widerps, osux, Linux
-				osc := osquery_types.OsqueryClient{
-					HostIdentifier:              data.HostIdentifier,
-					NodeKey:                     nodeKey,
-					NodeInvalid:                 false,
-					HostDetails:                 data.HostDetails,
-					PendingRegistrationApproval: true,
-					Tags:               []string{},
-					ConfigName:         "default",
-					ConfigurationGroup: "",
-				}
-				osc.Timestamp()
-				// might be good to check for dupe hostnames here before ACTUALLY issuing new key
-				err := dyndb.UpsertClient(osc, dynSvc, &mu)
-				if err != nil {
-					nodeEnrollRequestLogger.WithFields(log.Fields{
-						"hostname": data.HostIdentifier,
-					}).Info("failed to upsert  node")
-				}
 
-				js, _ := json.Marshal(enrollRequestResponse)
-				respWriter.Write(js)
-				return
+		dynSvc := dyndb.DbInstance()
 
-			}
+		if data.NodeKey != "" {
+			return fmt.Errorf("node key '%s' already exists in data", data.NodeKey)
 		}
+
+		//Need more error handling here.  what if node key is valid but hostname is duplicate?
+		ans, err := dyndb.SearchByHostIdentifier(data.HostIdentifier, dynSvc)
+		if err != nil {
+			return fmt.Errorf("failed to get node for host identifier '%s': %s", data.HostIdentifier, err)
+		}
+
+		switch len(ans) {
+		case 0:
+			// this will trigger a new enrollment request.  Upon creation of this request, it might be
+			//a good idea to generate a post event to an endpoint to notify of a pending enrollment
+			//approval
+			// this could also be taken care of by a separate worker that sweeps for pending enrollments.
+			// work may be better, as this task can be assigned to a lambda and gives more flexibility to the
+			//post endpoint
+			nodeKey := RandomString(20)
+			nodeEnrollRequestLogger.WithFields(log.Fields{
+				"hostname": data.HostIdentifier,
+			}).Info("generating new node_key")
+
+			// Handle enrollment defaults here.  Default configs for widerps, osux, Linux
+			osc := osquery_types.OsqueryClient{
+				ConfigName:                  "default",
+				HostDetails:                 data.HostDetails,
+				HostIdentifier:              data.HostIdentifier,
+				NodeKey:                     nodeKey,
+				PendingRegistrationApproval: true,
+			}
+
+			osc.SetTimestamp()
+			mu := sync.Mutex{}
+			// might be good to check for dupe hostnames here before ACTUALLY issuing new key
+			err := dyndb.UpsertClient(osc, dynSvc, &mu)
+			if err != nil {
+				nodeEnrollRequestLogger.WithFields(log.Fields{
+					"hostname": data.HostIdentifier,
+				}).Info("failed to upsert node")
+				return fmt.Errorf("node upsert failed: %s", err)
+			}
+
+			response.WriteCustomJSON(respWriter, EnrollRequestResponse{NodeKey: nodeKey, NodeInvalid: false})
+		default:
+			nodeEnrollRequestLogger.WithFields(log.Fields{
+				"hostname": data.HostIdentifier,
+			}).Info("host already exists, setting host to existing node_key")
+			osc := ans[0]
+			osc.SetTimestamp()
+			mu := sync.Mutex{}
+			err := dyndb.UpsertClient(osc, dynSvc, &mu)
+			if err != nil {
+				nodeEnrollRequestLogger.Error(err)
+				return fmt.Errorf("node upsert failed: %s", err)
+			}
+			// might be good to check for dupe hostnames here before ACTUALLY issuing new key
+			response.WriteCustomJSON(respWriter, EnrollRequestResponse{NodeKey: ans[0].NodeKey, NodeInvalid: false})
+		}
+
+		// TODO:
 		// if sekret is correct, check if node_key already configured
 		// if NOT node key, generate node key and create upsert to add node_key to pending
 		// if node key INVALID, return node_invalid
 		// if node key configured, check
-	} else {
-		respWriter.Header().Set("Content-Type", "application/json")
-		respWriter.Write([]byte(`{"node_invalid": true}`))
-		return
+
+		return nil
 	}
-	//fmt.Println(string(dump))
+
+	err := handleRequest()
+	if err != nil {
+		logger.Error(err)
+		errString := fmt.Sprintf("[NodeEnrollRequest] node enrolling failed: %s", err)
+		response.WriteError(respWriter, errString)
+	}
 }
 
+// NodeConfigureRequest configures a node
 func NodeConfigureRequest(respWriter http.ResponseWriter, request *http.Request) {
-	dump, _ := httputil.DumpRequest(request, true)
-	logger.Debug(string(dump))
-	dynSvc := dyndb.DbInstance()
-	//to recieve a valid config, node must have both a valid sekret and
-	//a node_key that is valid
-	body, err := ioutil.ReadAll(request.Body)
-	defer request.Body.Close()
-	logger := logger.WithFields(log.Fields{
+
+	handlerLogger := logger.WithFields(log.Fields{
 		"node_ip_address": request.RemoteAddr,
 		"user_agent":      request.UserAgent(),
 	})
-	if err != nil {
-		logger.Error(err)
-	}
-	var data NodeConfigurePost
-	// unmarshal post data into data
-	err = json.Unmarshal(body, &data)
-	if err != nil {
-		logger.Warn("unmarshal error")
-	}
 
-	err = dyndb.ValidNode(data.NodeKey, dynSvc)
-	if err != nil {
-		logger.Error(err)
-		respWriter.Header().Set("Content-Type", "application/json")
-		respWriter.Write([]byte(`{"node_invalid": true}`))
-		return
-	}
+	handleRequest := func() (interface{}, error) {
 
-	//query dyndb for node state with key
-	logger.WithFields(log.Fields{
-		"hostname": data.HostIdentifier,
-		"node_key": data.NodeKey,
-	}).Debug("valid node")
-	//get type of config for endpoint, return config
-	osqNode, err := dyndb.SearchByNodeKey(data.NodeKey, dynSvc)
-	osqNode.Timestamp()
-	if err != nil {
-		logger.Panic(err)
-	}
-	mu := sync.Mutex{}
-	err = dyndb.UpsertClient(osqNode, dynSvc, &mu)
-	if err != nil {
-		logger.Error(err)
-		return
-	}
-	namedConfig := osquery_types.OsqueryNamedConfig{}
-	if len(osqNode.ConfigName) > 0 {
-		namedConfig, err = dyndb.GetNamedConfig(dynSvc, osqNode.ConfigName)
+		dump, _ := httputil.DumpRequest(request, true)
+		logger.Debug(string(dump))
+
+		//to recieve a valid config, node must have both a valid sekret and
+		//a node_key that is valid
+		body, err := ioutil.ReadAll(request.Body)
+		defer request.Body.Close()
 		if err != nil {
-			logger.Panicf("[node.go]: Error returned when getting Named config: \n %s", err)
+			return nil, fmt.Errorf("failed to read request body: %s", err)
 		}
+
+		var data NodeConfigurePost
+		// unmarshal post data into data
+		err = json.Unmarshal(body, &data)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal failed: %s", err)
+		}
+
+		dynSvc := dyndb.DbInstance()
+		err = dyndb.ValidNode(data.NodeKey, dynSvc)
+		if err != nil {
+			return nil, fmt.Errorf("node validation failed for node with key '%s': %s", data.NodeKey, err)
+		}
+
+		//query dyndb for node state with key
+		logger.WithFields(log.Fields{
+			"hostname": data.HostIdentifier,
+			"node_key": data.NodeKey,
+		}).Debug("valid node")
+
+		//get type of config for endpoint, return config
+		osqNode, err := dyndb.SearchByNodeKey(data.NodeKey, dynSvc)
+		if err != nil {
+			return nil, fmt.Errorf("could not find node with key '%s': %s", data.NodeKey, err)
+		}
+
+		osqNode.SetTimestamp()
+		mu := sync.Mutex{}
+		err = dyndb.UpsertClient(osqNode, dynSvc, &mu)
+		if err != nil {
+			return nil, fmt.Errorf("node upsert failed: %s", err)
+		}
+
+		namedConfig := osquery_types.OsqueryNamedConfig{}
+		if osqNode.ConfigName != "" {
+			namedConfig, err = dyndb.GetNamedConfig(dynSvc, osqNode.ConfigName)
+			if err != nil {
+				return nil, fmt.Errorf("could not get config with name '%s': \n %s", osqNode.ConfigName, err)
+			}
+		} else {
+			handlerLogger.Info("No named config found, setting default config")
+			namedConfig, err = dyndb.GetNamedConfig(dynSvc, "default")
+			if err != nil {
+				return nil, fmt.Errorf("could not get default config: %s", err)
+			}
+		}
+
+		config, err := osquery_types.GetServerConfig("config.json")
+		if err != nil {
+			return nil, fmt.Errorf("could not get server config: %s", err)
+		}
+		//namedConfig.OsqueryConfig.Options.AwsAccessKeyID = os.Getenv("FIREHOSE_AWS_ACCESS_KEY_ID")
+		//namedConfig.OsqueryConfig.Options.AwsSecretAccessKey = os.Getenv("FIREHOSE_AWS_SECRET_ACCESS_KEY")
+		//namedConfig.OsqueryConfig.Options.AwsFirehoseStream = os.Getenv("AWS_FIREHOSE_STREAM")
+		handlerLogger.Debug(config)
+		namedConfig.OsqueryConfig.Options.AwsAccessKeyID = config.FirehoseAWSAccessKeyID
+		namedConfig.OsqueryConfig.Options.AwsSecretAccessKey = config.FirehoseAWSSecretAccessKey
+		if namedConfig.OsqueryConfig.Options.AwsFirehoseStream == "" {
+			namedConfig.OsqueryConfig.Options.AwsFirehoseStream = config.FirehoseStreamName
+		}
+		rawPackJSON := dyndb.BuildOsqueryPacksAsJSON(namedConfig)
+		namedConfig.OsqueryConfig.Packs = &rawPackJSON
+
+		return namedConfig.OsqueryConfig, nil
+	}
+
+	result, err := handleRequest()
+	if err != nil {
+		handlerLogger.Error(err)
+		errString := fmt.Sprintf("[NodeConfigureRequest] node configuration failed: %s", err)
+		response.WriteError(respWriter, errString)
 	} else {
-		logger.Info("No named config found, setting default config")
-		namedConfig, err = dyndb.GetNamedConfig(dynSvc, "default")
-		if err != nil {
-			logger.Panic(err)
-		}
+		response.WriteCustomJSON(respWriter, result)
 	}
-	config, err := osquery_types.GetServerConfig("config.json")
-	if err != nil {
-		logger.Error(err)
-		return
-	}
-	//namedConfig.OsqueryConfig.Options.AwsAccessKeyID = os.Getenv("FIREHOSE_AWS_ACCESS_KEY_ID")
-	//namedConfig.OsqueryConfig.Options.AwsSecretAccessKey = os.Getenv("FIREHOSE_AWS_SECRET_ACCESS_KEY")
-	//namedConfig.OsqueryConfig.Options.AwsFirehoseStream = os.Getenv("AWS_FIREHOSE_STREAM")
-	logger.Debug(config)
-	namedConfig.OsqueryConfig.Options.AwsAccessKeyID = config.FirehoseAWSAccessKeyID
-	namedConfig.OsqueryConfig.Options.AwsSecretAccessKey = config.FirehoseAWSSecretAccessKey
-	if namedConfig.OsqueryConfig.Options.AwsFirehoseStream == "" {
-		namedConfig.OsqueryConfig.Options.AwsFirehoseStream = config.FirehoseStreamName
-	}
-	rawPackJSON := dyndb.BuildOsqueryPacksAsJSON(namedConfig)
-	namedConfig.OsqueryConfig.Packs = &rawPackJSON
-	js, err := json.Marshal(namedConfig.OsqueryConfig)
-	if err != nil {
-		logger.Error(err)
-	}
-
-	respWriter.Header().Set("Content-Type", "application/json")
-	respWriter.Write(js)
 }

--- a/handlers/response/response.go
+++ b/handlers/response/response.go
@@ -1,0 +1,53 @@
+package response
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	statusError   = "error"
+	statusFailed  = "failed"
+	statusSuccess = "success"
+)
+
+// sgtBaseResponse stores some basic endpoint response values
+type sgtBaseResponse struct {
+	Message string `json:"message,omitempty"`
+	Status  string `json:"status"`
+}
+
+// SGTCustomResponse is an alias for a map that allows for
+// storing custom endpoint response values
+type SGTCustomResponse map[string]interface{}
+
+func getResponseJSON(response interface{}) []byte {
+
+	respJSON, err := json.Marshal(response)
+	if err != nil {
+		// If there is an error marshaling the interface, return a basic error
+		errString := fmt.Sprintf("response failed to marshal to json: %s", err)
+		newResp := sgtBaseResponse{Message: errString, Status: errString}
+		respJSON, _ = json.Marshal(newResp)
+	}
+	return respJSON
+}
+
+// WriteError will write the passed error to the http response writer
+func WriteError(respWriter http.ResponseWriter, errorString string) {
+	respWriter.Header().Set("Content-Type", "application/json")
+	respWriter.Write(getResponseJSON(sgtBaseResponse{Message: errorString, Status: statusError}))
+}
+
+// WriteSuccess will write the a success status and optional message to the http response writer
+func WriteSuccess(respWriter http.ResponseWriter, optionalMessage string) {
+	respWriter.Header().Set("Content-Type", "application/json")
+	respWriter.Write(getResponseJSON(sgtBaseResponse{Message: optionalMessage, Status: statusSuccess}))
+}
+
+// WriteCustom will write the custom response to the http response writer
+func WriteCustom(respWriter http.ResponseWriter, resp interface{}) {
+	respWriter.Header().Set("Content-Type", "application/json")
+	respWriter.Write(getResponseJSON(resp))
+}

--- a/handlers/response/response.go
+++ b/handlers/response/response.go
@@ -46,8 +46,8 @@ func WriteSuccess(respWriter http.ResponseWriter, optionalMessage string) {
 	respWriter.Write(getResponseJSON(sgtBaseResponse{Message: optionalMessage, Status: statusSuccess}))
 }
 
-// WriteCustom will write the custom response to the http response writer
-func WriteCustom(respWriter http.ResponseWriter, resp interface{}) {
+// WriteCustomJSON will write the custom response to the http response writer as json
+func WriteCustomJSON(respWriter http.ResponseWriter, resp interface{}) {
 	respWriter.Header().Set("Content-Type", "application/json")
 	respWriter.Write(getResponseJSON(resp))
 }

--- a/osquery_types/osquery_types.go
+++ b/osquery_types/osquery_types.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
-	"github.com/oktasecuritylabs/sgt/logger"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -24,7 +22,8 @@ type OsqueryClient struct {
 	LastUpdated                 string                       `json:"last_updated"`
 }
 
-func (os *OsqueryClient) Timestamp() {
+// SetTimestamp sets the current timestamp with the proper format
+func (os *OsqueryClient) SetTimestamp() {
 	os.LastUpdated = time.Now().UTC().Format("Mon, 01/02/06, 03:04:05PM")
 }
 
@@ -264,16 +263,19 @@ type DistributedQuery struct {
 	NodeInvalid bool     `json:"node_invalid"`
 }
 
-func (dq DistributedQuery) ToJson() string {
-	js := `{"queries": {`
-	var querylist []string
+// ToJSON returns a formatted version of the DistributedQuery
+func (dq DistributedQuery) ToJSON() string {
+	result := make(map[string]interface{})
+	querylist := make(map[string]string)
 	for i, j := range dq.Queries {
-		querylist = append(querylist, fmt.Sprintf(`"id%d": "%s"`, i+1, j))
+		querylist[fmt.Sprintf("id%d", i+1)] = j
 	}
-	qstrings := strings.Join(querylist, ",")
-	js += qstrings
-	js += fmt.Sprintf(`}, "node_invalid": %s}`, strconv.FormatBool(dq.NodeInvalid))
-	return js
+	result["queries"] = querylist
+	result["node_invalid"] = strconv.FormatBool(dq.NodeInvalid)
+
+	js, _ := json.Marshal(result)
+
+	return string(js)
 }
 
 type ServerConfig struct {

--- a/osquery_types/osquery_types.go
+++ b/osquery_types/osquery_types.go
@@ -287,17 +287,19 @@ type ServerConfig struct {
 }
 
 func GetServerConfig(fn string) (ServerConfig, error) {
+
+	config := ServerConfig{}
 	file, err := os.Open(fn)
 	if err != nil {
-		logger.Error(err)
-	}
-	decoder := json.NewDecoder(file)
-	config := ServerConfig{}
-	err = decoder.Decode(&config)
-	if err != nil {
-		logger.Error(err)
 		return config, err
 	}
+
+	decoder := json.NewDecoder(file)
+	err = decoder.Decode(&config)
+	if err != nil {
+		return config, err
+	}
+
 	return config, nil
 }
 
@@ -308,12 +310,7 @@ type User struct {
 }
 
 func (u User) Validate(plaintext_pw string) error {
-	err := bcrypt.CompareHashAndPassword(u.Password, []byte(plaintext_pw))
-	if err != nil {
-		logger.Error(err)
-		return err
-	}
-	return nil
+	return bcrypt.CompareHashAndPassword(u.Password, []byte(plaintext_pw))
 }
 
 type DistributedQueryResult struct {

--- a/server/server.go
+++ b/server/server.go
@@ -22,19 +22,19 @@ func Serve() error {
 	//Configuration (management) endpoint
 	apiRouter := mux.NewRouter().PathPrefix("/api/v1/configuration").Subrouter()
 
-	apiRouter.HandleFunc("/configs", api.GetNamedConfigs).Methods("GET", "POST")
-	apiRouter.HandleFunc("/configs/{config_name}", api.ConfigurationRequest).Methods("POST")
+	apiRouter.HandleFunc("/configs", api.GetNamedConfigs).Methods(http.MethodGet, http.MethodPost)
+	apiRouter.HandleFunc("/configs/{config_name}", api.ConfigurationRequest).Methods(http.MethodPost)
 	//Nodes
-	apiRouter.HandleFunc("/nodes", api.GetNodes).Methods("GET")
-	apiRouter.HandleFunc("/nodes/{node_key}", api.ConfigureNode).Methods("POST", "GET")
-	apiRouter.HandleFunc("/nodes/{node_key}/approve", api.ApproveNode).Methods("POST")
+	apiRouter.HandleFunc("/nodes", api.GetNodes).Methods(http.MethodGet)
+	apiRouter.HandleFunc("/nodes/{node_key}", api.ConfigureNode).Methods(http.MethodPost, http.MethodGet)
+	apiRouter.HandleFunc("/nodes/{node_key}/approve", api.ApproveNode).Methods(http.MethodPost)
 	//apiRouter.HandleFunc("/nodes/approve/_bulk", api.Placeholder).Methods("POST)
 	//Packs
-	apiRouter.HandleFunc("/packs", api.GetQueryPacks).Methods("GET")
-	apiRouter.HandleFunc("/packs/search/{search_string}", api.SearchQueryPacks).Methods("GET")
-	apiRouter.HandleFunc("/packs/{pack_name}", api.ConfigurePack).Methods("POST")
+	apiRouter.HandleFunc("/packs", api.GetQueryPacks).Methods(http.MethodGet)
+	apiRouter.HandleFunc("/packs/search/{search_string}", api.SearchQueryPacks).Methods(http.MethodGet)
+	apiRouter.HandleFunc("/packs/{pack_name}", api.ConfigurePack).Methods(http.MethodPost)
 	//PackQueries
-	apiRouter.HandleFunc("/packqueries", api.GetPackQueries).Methods("GET")
+	apiRouter.HandleFunc("/packqueries", api.GetPackQueries).Methods(http.MethodGet)
 	apiRouter.HandleFunc("/packqueries/{query_name}", api.ConfigurePackQuery)
 	apiRouter.HandleFunc("/packqueries/search/{search_string}", api.SearchPackQueries)
 	apiRouter.HandleFunc("/distributed/add", distributed.DistributedQueryAdd)


### PR DESCRIPTION
to @securityclippy 


### Changes

* Updating server, deploy, api and node packages to use `http.MethodGet`, `http.MethodPost`, etc constants instead of string literals
* Adding a `response` package with helpers for handling the marshaling/writing of endpoint responses
* Updating the `osquery_types` package so the `user.Validate` func and and `GetServerConfig` methods to return their errors since the caller handles logging/raising of the error.
* Updating all http request handlers in the `api`, `node`, `auth`, and `distributed` packages to handle and report errors more granularly.
  * This uses a nested `func` variable named `handleRequest` within each of these handlers that allows for returning errors with context that will be written to the `http.ResponseWriter`.
  * The `response` package has helpers for writing to the `http.ResponseWriter` that is passed in. The helpers allow for writing a generic `interface` that is marshaled to json, and writing error/success json payloads.
* `UpsertPack` func refactor for clarity and misc fixes

### Testing

* Build with `go build` is successful and this resolves a few `govet` issues.
