### PR TITLE
[http] fixing some areas where http.Request.Body.Close() was not called

### DIFF
--- a/handlers/api/api.go
+++ b/handlers/api/api.go
@@ -76,6 +76,7 @@ func ConfigurationRequest(respWriter http.ResponseWriter, request *http.Request)
 
 			// finally...
 			body, err := ioutil.ReadAll(request.Body)
+			defer request.Body.Close()
 			if err != nil {
 				return nil, fmt.Errorf("failed to read request body: %s", err)
 			}

--- a/handlers/auth/auth.go
+++ b/handlers/auth/auth.go
@@ -136,7 +136,9 @@ func ValidateUser(request *http.Request) error {
 		Username string `json:"username"`
 		Password string `json:"password"`
 	}
+
 	body, err := ioutil.ReadAll(request.Body)
+	defer request.Body.Close()
 	if err != nil {
 		panic(err)
 	}
@@ -250,13 +252,14 @@ func ValidNodeKey(respWriter http.ResponseWriter, req *http.Request, next http.H
 
 		dynDB := dyndb.DbInstance()
 		respWriter.Header().Set("Content-Type", "application/json")
+
 		body, err := ioutil.ReadAll(req.Body)
-		req.Body.Close()
+		defer req.Body.Close()
+		if err != nil {
+			return fmt.Errorf("failed to read request body: %s", err)
+		}
 
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-		if err != nil {
-			return err
-		}
 
 		var data NodeConfigurePost
 		// unmarshal post data into data

--- a/handlers/distributed/distributed.go
+++ b/handlers/distributed/distributed.go
@@ -81,8 +81,7 @@ func DistributedQueryRead(respWriter http.ResponseWriter, request *http.Request)
 func ParseDistributedResults(request *http.Request) ([]osquery_types.DistributedQueryResult, error) {
 	results := []osquery_types.DistributedQueryResult{}
 	body, err := ioutil.ReadAll(request.Body)
-	//logger.Info(string(body))
-	//err = json.Unmarshal(body, &dw)
+	defer request.Body.Close()
 	if err != nil {
 		logger.Error(err)
 		return results, err

--- a/handlers/node/node.go
+++ b/handlers/node/node.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	nodeInvalid = true
-	nodeValid = false
+	nodeValid   = false
 )
 
 type EnrollRequestResponse struct {
@@ -81,8 +81,8 @@ func NodeEnrollRequest(respWriter http.ResponseWriter, request *http.Request) {
 		})
 
 		body, err := ioutil.ReadAll(request.Body)
-		logger.Info(string(body))
 		defer request.Body.Close()
+		logger.Info(string(body))
 		if err != nil {
 			nodeEnrollRequestLogger.Error(err)
 			return fmt.Errorf("failed to read request body: %s", err)
@@ -279,7 +279,7 @@ func NodeConfigureRequest(respWriter http.ResponseWriter, request *http.Request)
 		handlerLogger.Error(err)
 		errString := fmt.Sprintf("[NodeConfigureRequest] node configuration failed: %s", err)
 		logger.Error(errString)
-		result := EnrollRequestResponse{NodeInvalid:nodeInvalid}
+		result := EnrollRequestResponse{NodeInvalid: nodeInvalid}
 		response.WriteCustomJSON(respWriter, result)
 	} else {
 		response.WriteCustomJSON(respWriter, result)


### PR DESCRIPTION
to @securityclippy 
size: small

### Changes

* Resolving a few places where the `http.Request.Body` did not have `Close()` called.
* Updating other areas that call `defer request.Body.Close()` to happen before the body is read.
  * This change is for consistency, and groups the calls for closing/reading more closely together.
* Removing an ineffectual assign to `stdoutStderr` in the `deployAWSComponent` func of `deploy/apply.go` that was not being checked or used for anything.
* Checking some errors in the `createElasticSearchMappings` func of `deploy/apply.go` that were otherwise ignored (particularly with `http.NewRequest` and `ioutil.ReadAll`).

### Testing

* Still building with `go build`
