### PR TITLE
[api] using io.WriteString for writing responses instead of http.ResponseWriter.Write(...)

### DIFF
--- a/handlers/distributed/distributed.go
+++ b/handlers/distributed/distributed.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -62,7 +63,7 @@ func DistributedQueryRead(respWriter http.ResponseWriter, request *http.Request)
 			return errors.New("no queries in list: %s")
 		}
 
-		respWriter.Write([]byte(distributedQuery.ToJSON()))
+		io.WriteString(respWriter, distributedQuery.ToJSON())
 		err = dyndb.DeleteDistributedQuery(distributedQuery, dynSvc)
 		if err != nil {
 			return fmt.Errorf("could not delete query: %s", err)


### PR DESCRIPTION
to: @securityclippy 
size: small

### Changes

* Now using `io.WriteString` to write http responses due to part of an answer found [here](https://stackoverflow.com/a/37872799):

  > All in all, whenever you write string values, [it's] recommended to use io.WriteString() as it may be more efficient (faster).
* Also updating how _unexpected_ errors are reported to the user by using `http.Error` instead of attempting to write a custom error struct.