### PR TITLE
fixed typo and cognito param

### DIFF
--- a/handlers/deploy/apply.go
+++ b/handlers/deploy/apply.go
@@ -324,7 +324,7 @@ func createElasticSearchCognitoOptions(currentRegion string, config DeploymentCo
                     Username: aws.String(DesiredUser),
                     UserAttributes: []*cognitoidentityprovider.AttributeType{
                         {Name: aws.String("email"),Value : aws.String(DesiredUser+"@"+MailDomain)},
-                        {Name: aws.String("email_verified"),Value : aws.String("true")}
+                        {Name: aws.String("email_verified"),Value : aws.String("true")},
                     },
                 })
                 if err != nil {

--- a/handlers/deploy/apply.go
+++ b/handlers/deploy/apply.go
@@ -324,6 +324,7 @@ func createElasticSearchCognitoOptions(currentRegion string, config DeploymentCo
                     Username: aws.String(DesiredUser),
                     UserAttributes: []*cognitoidentityprovider.AttributeType{
                         {Name: aws.String("email"),Value : aws.String(DesiredUser+"@"+MailDomain)},
+                        {Name: aws.String("email_verified"),Value : aws.String("true")}
                     },
                 })
                 if err != nil {

--- a/terraform/example/example_environment.json
+++ b/terraform/example/example_environment.json
@@ -13,7 +13,7 @@
   "sgt_app_secret": "ultra_mega_sekret_key_you'll_never_give_to_anyone_not_even_your_mother",
   "create_elasticsearch": 1,
   "asg_min_size": 2,
-  "asg_max_size": 10
+  "asg_max_size": 10,
   "mail_domain": "example.com",
   "users": [
       "first.last",


### PR DESCRIPTION
Adding the email_verified parameter to the cognito create user requests makes it so users can reset their passwords later if they forget them.