### PR TITLE
adding better support for uuid

### DIFF
--- a/handlers/helpers/dbtesthelpers.go
+++ b/handlers/helpers/dbtesthelpers.go
@@ -43,6 +43,7 @@ var testClient1 = osquery_types.OsqueryClient{
 	"host1",
 	"3lkjsdf0jdfoiasdjf",
 	false,
+	"testhost",
 	map[string]map[string]string{},
 	false,
 	[]string{"a", "b"},

--- a/handlers/node/node.go
+++ b/handlers/node/node.go
@@ -138,6 +138,7 @@ func NodeEnrollRequest(dyn NodeDB, config *osquery_types.ServerConfig) http.Hand
 					ConfigName:     "default",
 					HostDetails:    data.HostDetails,
 					HostIdentifier: data.HostIdentifier,
+					HostName:       data.HostDetails["system_info"]["computer_name"],
 					NodeKey:        nodeKey,
 					//if autoenroll enabled, set pending to false
 					PendingRegistrationApproval: !autoApprove,

--- a/osquery_configs/defaults/default-linux.json
+++ b/osquery_configs/defaults/default-linux.json
@@ -18,7 +18,7 @@
     "events_expiry": 300,
     "events_max": 100000,
     "event_optimize": true,
-    "host_identifier": "hostname",
+    "host_identifier": "uuid",
     "logger_plugin": "aws_firehose",
     "watchdog_level": -1,
     "watchdog_memory_limit": 300

--- a/osquery_configs/defaults/default-mac.json
+++ b/osquery_configs/defaults/default-mac.json
@@ -18,7 +18,7 @@
     "events_expiry": 300,
     "events_max": 100000,
     "event_optimize": true,
-    "host_identifier": "hostname",
+    "host_identifier": "uuid",
     "logger_plugin": "aws_firehose",
     "watchdog_level": -1,
     "watchdog_memory_limit": 300

--- a/osquery_configs/defaults/default-windows.json
+++ b/osquery_configs/defaults/default-windows.json
@@ -18,7 +18,7 @@
     "events_expiry": 300,
     "events_max": 100000,
     "event_optimize": true,
-    "host_identifier": "hostname",
+    "host_identifier": "uuid",
     "logger_plugin": "aws_firehose",
     "watchdog_level": -1,
     "watchdog_memory_limit": 300

--- a/osquery_configs/defaults/default.json
+++ b/osquery_configs/defaults/default.json
@@ -18,7 +18,7 @@
     "events_expiry": 300,
     "events_max": 100000,
     "event_optimize": true,
-    "host_identifier": "hostname",
+    "host_identifier": "uuid",
     "logger_plugin": "aws_firehose",
     "watchdog_level": -1,
     "watchdog_memory_limit": 300

--- a/osquery_types/osquery_types.go
+++ b/osquery_types/osquery_types.go
@@ -14,7 +14,7 @@ type OsqueryClient struct {
 	HostIdentifier              string                       `json:"host_identifier"`
 	NodeKey                     string                       `json:"node_key"`
 	NodeInvalid                 bool                         `json:"node_invalid"`
-	HostName					string						 `json:"host_name"`
+	HostName                    string                       `json:"host_name"`
 	HostDetails                 map[string]map[string]string `json:"host_details"`
 	PendingRegistrationApproval bool                         `json:"pending_registration_approval"`
 	Tags                        []string                     `json:"tags,omitempty"`

--- a/osquery_types/osquery_types.go
+++ b/osquery_types/osquery_types.go
@@ -14,6 +14,7 @@ type OsqueryClient struct {
 	HostIdentifier              string                       `json:"host_identifier"`
 	NodeKey                     string                       `json:"node_key"`
 	NodeInvalid                 bool                         `json:"node_invalid"`
+	HostName					string						 `json:"host_name"`
 	HostDetails                 map[string]map[string]string `json:"host_details"`
 	PendingRegistrationApproval bool                         `json:"pending_registration_approval"`
 	Tags                        []string                     `json:"tags,omitempty"`


### PR DESCRIPTION
added first level support for distinct hostname field in dynamo, allowing uuid as the host-identifier in the osquery config.

changed default configs to use uuid as host_identifier by default